### PR TITLE
feat: Update README and config for Opus download options, disable emb…

### DIFF
--- a/scripts/audio-workflow/download/README.md
+++ b/scripts/audio-workflow/download/README.md
@@ -40,10 +40,32 @@ Defaults live in `download-yt-song.config.json` (copyable from the `.example` fi
 - `playlist-url` – primary playlist to monitor
 - `output-dir` – local folder for downloaded assets (default `downloads/yt-music`)
 - `format-order` – preference list such as `opus,wav,mp3`
+- `write-thumbnail` – keep a `.webp` cover next to the audio (default: on)
+- `embed-thumbnail` – attach artwork to the container (default: off to keep Opus lean)
+- `add-metadata` – inject tags into the container (default: off; metadata lives in JSON)
 - `player-client` / `po-token` – control which YouTube client yt-dlp impersonates
 - `archive` – path to the `.yt-dlp-archive.txt` file for duplicate protection
 
 CLI flags always override config values, so you can keep long-term defaults committed and tweak per run.
+
+## Metadata and Artwork Defaults
+
+The downloader now leaves thumbnails and tags **outside** the Opus container by default to keep the downloaded audio small. You still get:
+
+- `.webp` artwork saved alongside the audio file
+- `.metadata.json` + `.info.json` sidecars with the full yt-dlp metadata payload
+
+If you really need embedded art and tags, pass both flags when running the script:
+
+```bash
+npm run download-song -- --item 1 --embed-thumbnail --add-metadata
+```
+
+To verify a download stayed lean, inspect the streams and confirm there's no `attached_pic` entry:
+
+```bash
+ffprobe -v error -show_streams "downloads/yt-music/01 - Track.opus" | grep attached_pic
+```
 
 ## What You Get
 
@@ -52,6 +74,6 @@ For each track the script can optionally emit:
 - The encoded audio file (prefers native Opus, falls back per `format-order`)
 - `*.metadata.json` with playlist context, codecs, and filesystem paths
 - yt-dlp `.info.json` (when `--write-info-json` is enabled)
-- Thumbnail image and embedded metadata (configurable via flags)
+- Thumbnail image saved as `.webp` (embedding disabled by default; toggle with flags as needed)
 
 These artifacts feed directly into the Organize + Encode stage, which expects the metadata JSON files to sit alongside the raw downloads.

--- a/scripts/audio-workflow/download/download-yt-song.config.example.json
+++ b/scripts/audio-workflow/download/download-yt-song.config.example.json
@@ -9,5 +9,7 @@
   "metadata": true,
   "write-info-json": true,
   "write-thumbnail": true,
+  "embed-thumbnail": false,
+  "add-metadata": false,
   "cookies-from-browser": "chrome"
 }

--- a/scripts/audio-workflow/download/download-yt-song.config.json
+++ b/scripts/audio-workflow/download/download-yt-song.config.json
@@ -8,5 +8,7 @@
   "rate-limit": "3M",
   "metadata": true,
   "write-info-json": true,
-  "write-thumbnail": true
+  "write-thumbnail": true,
+  "embed-thumbnail": false,
+  "add-metadata": false
 }

--- a/scripts/audio-workflow/download/download-yt-song.js
+++ b/scripts/audio-workflow/download/download-yt-song.js
@@ -79,12 +79,12 @@ const writeInfoJson = options['no-info-json']
 const writeThumbnail = options['no-thumbnails']
   ? false
   : toBoolean(options['write-thumbnail'] ?? options.thumbnails, metadataEnabled);
-const embedThumbnail = options['no-embed-thumbnail']
-  ? false
-  : toBoolean(options['embed-thumbnail'], metadataEnabled);
-const addMetadata = options['no-add-metadata']
-  ? false
-  : toBoolean(options['add-metadata'], metadataEnabled);
+const embedThumbnail =
+  metadataEnabled &&
+  (options['no-embed-thumbnail'] ? false : toBoolean(options['embed-thumbnail'], false));
+const addMetadata =
+  metadataEnabled &&
+  (options['no-add-metadata'] ? false : toBoolean(options['add-metadata'], false));
 
 const archiveDisabled = toBoolean(options['no-archive'], false);
 const downloadArchive = archiveDisabled
@@ -885,6 +885,8 @@ Options:
 	--metadata / --no-metadata   Toggle metadata sidecars, tags, and thumbnails
 	--no-info-json               Skip writing the .info.json metadata file
 	--no-thumbnails              Skip thumbnail download/embedding
+  --embed-thumbnail            Embed inline thumbnail art (default: off)
+  --add-metadata               Write tags into the container (default: off)
   --write-index / --no-index   Toggle machine-readable per-track metadata index files (default: on)
   --sleep-requests <seconds>   Friendly throttle between requests (default: 0.5)
   --min-sleep-interval <sec>   Minimum random delay when throttling (default: --sleep-requests)


### PR DESCRIPTION
This pull request introduces new options for controlling how metadata and artwork are handled when downloading YouTube songs, with a focus on keeping Opus audio files small by default. The documentation and configuration files have been updated to reflect these changes, and the script logic now ensures that artwork and tags are only embedded when explicitly requested.

**Metadata and Artwork Handling:**

* Added `embed-thumbnail` and `add-metadata` options to config files (`download-yt-song.config.json`, `download-yt-song.config.example.json`) to control whether artwork and tags are embedded in the audio container (default: off). [[1]](diffhunk://#diff-496d3bc9c694e9f213cc35644d55efc3cf9a65858e74422185f7fd38e59c69f6L11-R13) [[2]](diffhunk://#diff-4c62905a94a0e2a7a2c0c4c929d6cd843044d947ab99c2be9860a7e95079944dR12-R13)
* Updated script logic in `download-yt-song.js` to only embed thumbnails and metadata tags if both metadata is enabled and the corresponding flags are set, ensuring lean Opus files by default.
* Expanded CLI options in `download-yt-song.js` to include `--embed-thumbnail` and `--add-metadata` flags for explicit control over embedding artwork and tags.

**Documentation Updates:**

* Improved `README.md` to clarify the default behavior for metadata and artwork, explain how to enable embedding, and provide instructions for verifying audio file size and content.