### PR TITLE
fix(worker): allow no-origin media requests to prevent audio 403

### DIFF
--- a/cloudflare/worker.test.ts
+++ b/cloudflare/worker.test.ts
@@ -76,6 +76,28 @@ describe('Cloudflare worker', () => {
     expect(await response.text()).toBe('audio-data');
   });
 
+  it('serves audio for requests without an Origin header', async () => {
+    const env = createEnv();
+    const response = await worker.fetch(createRequest('/prod/audio/test.opus'), env);
+
+    expect(response.status).toBe(200);
+    expect(env.AUDIO.head).toHaveBeenCalledWith('prod/audio/test.opus');
+    expect(env.AUDIO.get).toHaveBeenCalledWith('prod/audio/test.opus', undefined);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(response.headers.get('Access-Control-Expose-Headers')).toBe(
+      'Content-Length, Content-Range, Content-Type, ETag, Accept-Ranges'
+    );
+  });
+
+  it('rejects requests without Origin when shared secret is configured', async () => {
+    const env = createEnv({ sharedSecret: 'secret' });
+    const response = await worker.fetch(createRequest('/prod/audio/test.opus'), env);
+
+    expect(response.status).toBe(403);
+    expect(env.AUDIO.head).not.toHaveBeenCalled();
+    expect(env.AUDIO.get).not.toHaveBeenCalled();
+  });
+
   it('allows wildcard origins that match the configured pattern', async () => {
     const env = createEnv({ allowedOrigins: 'https://photo-signal-*.vercel.app' });
     const response = await worker.fetch(

--- a/cloudflare/worker.ts
+++ b/cloudflare/worker.ts
@@ -226,16 +226,19 @@ export default {
     const url = new URL(request.url);
     const allowedOrigins = parseAllowedOrigins(env.ALLOWED_ORIGINS);
     const origin = request.headers.get('Origin');
+    const isNonCorsRequest = !origin;
     const matchedOrigin = matchAllowedOrigin(origin, allowedOrigins);
+    const requiresSecretForNonCors = isNonCorsRequest && Boolean(env.SHARED_SECRET);
     const hasSharedSecret =
       Boolean(env.SHARED_SECRET) &&
       safeCompare(request.headers.get('X-PS-Shared-Secret'), env.SHARED_SECRET);
     const allowAnyOrigin = hasSharedSecret;
-    const originAllowed = Boolean(matchedOrigin) || allowAnyOrigin;
+    const nonCorsAllowed = isNonCorsRequest && (!requiresSecretForNonCors || hasSharedSecret);
+    const originAllowed = Boolean(matchedOrigin) || allowAnyOrigin || nonCorsAllowed;
     const corsOrigin = allowAnyOrigin ? (origin ?? matchedOrigin) : matchedOrigin;
 
     if (request.method === 'OPTIONS') {
-      if (!originAllowed) {
+      if (!origin || !originAllowed) {
         return new Response('Forbidden', { status: 403, headers: { Vary: 'Origin' } });
       }
       return new Response(null, {


### PR DESCRIPTION
## What
- Allow GET/HEAD requests without an Origin header in the Cloudflare Worker
- Keep CORS enforcement for explicit origins
- Continue requiring SHARED_SECRET for non-CORS requests when configured
- Add regression tests for no-origin success and secret-gated no-origin rejection

## Why
Some browser/media-element audio requests can omit the Origin header. The worker previously returned 403 for those requests, causing playback failures (Howler load error 4) even when CORS probes returned 200.

## Validation
- npm run pre-commit
- npm run test:run -- cloudflare/worker.test.ts
- Live verification after deploy:
  - with Origin: 200
  - without Origin: 200

## Notes
- Worker fix already deployed for immediate incident recovery: version 407e5dc3-7283-4bde-8998-2af681cef5ae.
