### PR TITLE
Fix rectangle overlay rendering and video sizing

### DIFF
--- a/src/modules/camera-view/CameraView.module.css
+++ b/src/modules/camera-view/CameraView.module.css
@@ -86,8 +86,6 @@
   transform: translate(-50%, -50%);
   aspect-ratio: 1 / 1;
   object-fit: cover;
-  max-width: min(100vw, 100vh);
-  max-height: min(100vw, 100vh);
   width: 100%;
   height: auto;
 }

--- a/src/modules/camera-view/CameraView.test.tsx
+++ b/src/modules/camera-view/CameraView.test.tsx
@@ -331,4 +331,85 @@ describe('CameraView', () => {
       expect(screen.queryByText('Point camera at a photo to play music')).not.toBeInTheDocument();
     });
   });
+
+  describe('Rectangle Detection Overlay', () => {
+    let mockStream: MediaStream;
+    const mockRectangle = {
+      topLeft: { x: 0.1, y: 0.1 },
+      topRight: { x: 0.9, y: 0.1 },
+      bottomRight: { x: 0.9, y: 0.9 },
+      bottomLeft: { x: 0.1, y: 0.9 },
+      width: 0.8,
+      height: 0.8,
+      aspectRatio: 1,
+    };
+
+    beforeEach(() => {
+      mockStream = new MediaStream();
+    });
+
+    it('should show detecting status when rectangle detected below confidence threshold', () => {
+      render(
+        <CameraView
+          stream={mockStream}
+          error={null}
+          hasPermission={true}
+          showRectangleOverlay={true}
+          detectedRectangle={mockRectangle}
+          rectangleConfidence={0.3}
+          rectangleDetectionConfidenceThreshold={0.6}
+        />
+      );
+
+      expect(screen.getByText('Detecting photo...')).toBeInTheDocument();
+    });
+
+    it('should show detected status when rectangle confidence meets threshold', () => {
+      render(
+        <CameraView
+          stream={mockStream}
+          error={null}
+          hasPermission={true}
+          showRectangleOverlay={true}
+          detectedRectangle={mockRectangle}
+          rectangleConfidence={0.8}
+          rectangleDetectionConfidenceThreshold={0.6}
+        />
+      );
+
+      expect(screen.getByText('Photo detected!')).toBeInTheDocument();
+    });
+
+    it('should not render overlay when showRectangleOverlay is false', () => {
+      render(
+        <CameraView
+          stream={mockStream}
+          error={null}
+          hasPermission={true}
+          showRectangleOverlay={false}
+          detectedRectangle={mockRectangle}
+          rectangleConfidence={0.8}
+        />
+      );
+
+      expect(screen.queryByText('Photo detected!')).not.toBeInTheDocument();
+      expect(screen.queryByText('Detecting photo...')).not.toBeInTheDocument();
+    });
+
+    it('should not render overlay when detectedRectangle is null', () => {
+      render(
+        <CameraView
+          stream={mockStream}
+          error={null}
+          hasPermission={true}
+          showRectangleOverlay={true}
+          detectedRectangle={null}
+          rectangleConfidence={0}
+        />
+      );
+
+      expect(screen.queryByText('Photo detected!')).not.toBeInTheDocument();
+      expect(screen.queryByText('Detecting photo...')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/modules/camera-view/CameraView.tsx
+++ b/src/modules/camera-view/CameraView.tsx
@@ -67,7 +67,7 @@ export function CameraView({
       />
 
       {/* Rectangle Detection Overlay */}
-      {showRectangleOverlay && videoRef.current && (
+      {showRectangleOverlay && (
         <RectangleOverlay
           rectangle={detectedRectangle}
           state={


### PR DESCRIPTION
## What

Fixed rectangle detection overlay rendering logic and removed unnecessary CSS constraints on video element sizing.

## Why

The rectangle overlay was conditionally checking for `videoRef.current` existence before rendering, which was unnecessary since the overlay is a separate canvas element that doesn't depend on the video ref being mounted. This could cause the overlay to not render in certain timing scenarios. Additionally, the CSS `max-width` and `max-height` constraints using `min(100vw, 100vh)` were redundant given the `width: 100%` and `height: auto` properties already defined.

## How

- Removed the `videoRef.current` check from the rectangle overlay render condition, keeping only the `showRectangleOverlay` check
- Removed the redundant `max-width` and `max-height` CSS properties from the video element styles
- Added comprehensive unit tests for the rectangle detection overlay covering:
  - Detecting status when confidence is below threshold
  - Detected status when confidence meets threshold
  - Overlay not rendering when `showRectangleOverlay` is false
  - Overlay not rendering when `detectedRectangle` is null

## Testing

- Added 4 new unit tests in `CameraView.test.tsx` covering all rectangle overlay rendering scenarios
- Tests verify both the presence and absence of overlay UI elements based on props
- Existing tests continue to pass

## Notes

The rectangle overlay component itself handles null rectangle values, so the overlay can safely render without the video ref check. The CSS changes simplify the styling without affecting visual behavior since the video element is already constrained by its container.

https://claude.ai/code/session_01YFvnDUf8aQJSsUcp4YDm7o