### PR TITLE
Stop camera, recognition, and audio when app is hidden or closed

### DIFF
--- a/src/App.playbackFlow.test.tsx
+++ b/src/App.playbackFlow.test.tsx
@@ -55,6 +55,7 @@ const mockPause = vi.fn();
 const mockPreload = vi.fn();
 const mockFadeOut = vi.fn();
 const mockCrossfade = vi.fn();
+const mockStop = vi.fn();
 const mockSetVolume = vi.fn();
 const mockClearPlaybackError = vi.fn();
 
@@ -202,7 +203,7 @@ vi.mock('./modules/audio-playback', () => ({
     progress: audioState.progress,
     playbackError: audioState.playbackError,
     clearPlaybackError: mockClearPlaybackError,
-    stop: vi.fn(),
+    stop: mockStop,
     volume: 0.8,
     setVolume: mockSetVolume,
   }),
@@ -270,6 +271,40 @@ describe('App playback flow', () => {
     expect(
       screen.getByText('Signal is locked. Playback runs continuously until you pause.')
     ).toBeInTheDocument();
+  });
+
+  it('stops playback and exits active mode when app is hidden', async () => {
+    recognitionState.recognizedConcert = concertOne;
+
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Activate camera and begin experience',
+      })
+    );
+
+    expect(mockPlay).toHaveBeenCalledWith('/audio/one.opus');
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'hidden',
+    });
+    fireEvent(document, new Event('visibilitychange'));
+
+    expect(mockStop).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole('button', {
+        name: 'Activate camera and begin experience',
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText('Now playing controls')).not.toBeInTheDocument();
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
   });
 
   it('shows matched details and keeps switch controls hidden while details are visible', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -317,6 +317,7 @@ function AppContent() {
   const {
     play,
     pause,
+    stop,
     preload,
     crossfade,
     isPlaying,
@@ -672,6 +673,51 @@ function AppContent() {
     attemptPortraitOrientationLock();
     setIsActive(true);
   };
+
+  const shutdownExperience = useCallback(() => {
+    userPausedRef.current = true;
+    stop();
+    setIsActive(false);
+    setIsConcertInfoVisible(false);
+    setHasScannedPhotoLoadFailed(false);
+    setPendingSwitchConcert(null);
+    setDismissedSwitchBand(null);
+    setClosedConcertCooldown(null);
+    setActiveConcert(null);
+    setActivePlaylistBand(null);
+    playlistRef.current = [];
+    playlistIndexRef.current = 0;
+    previousAutoplayIdRef.current = null;
+    promptShownAtRef.current = null;
+    lastPromptConcertIdRef.current = null;
+    resetRecognition();
+  }, [resetRecognition, stop]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        shutdownExperience();
+      }
+    };
+
+    const handlePageHide = () => {
+      shutdownExperience();
+    };
+
+    const handleBeforeUnload = () => {
+      shutdownExperience();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [shutdownExperience]);
 
   const infoConcert = isConcertInfoVisible
     ? (pendingSwitchConcert ?? activeRecognitionConcert ?? activeConcert)

--- a/src/modules/camera-access/useCameraAccess.test.ts
+++ b/src/modules/camera-access/useCameraAccess.test.ts
@@ -224,6 +224,26 @@ describe('useCameraAccess', () => {
     });
   });
 
+  describe('autoStart lifecycle behavior', () => {
+    it('stops current stream when autoStart is toggled to false', async () => {
+      const { result, rerender } = renderHook(({ autoStart }) => useCameraAccess({ autoStart }), {
+        initialProps: { autoStart: true },
+      });
+
+      await waitFor(() => {
+        expect(result.current.stream).toBe(mockStream);
+      });
+
+      rerender({ autoStart: false });
+
+      await waitFor(() => {
+        expect(result.current.stream).toBeNull();
+      });
+
+      expect(mockTrack.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('Retry functionality', () => {
     it('should provide a retry method', () => {
       const { result } = renderHook(() => useCameraAccess());

--- a/src/modules/camera-access/useCameraAccess.ts
+++ b/src/modules/camera-access/useCameraAccess.ts
@@ -68,10 +68,21 @@ export function useCameraAccess(options: CameraAccessOptions = {}): CameraAccess
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const stopCurrentStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    }
+
+    setStream(null);
+  }, []);
+
   const startCamera = useCallback(async () => {
     try {
       setError(null);
       setHasPermission(null);
+
+      stopCurrentStream();
 
       const mediaStream = await navigator.mediaDevices.getUserMedia(getCameraConstraints());
 
@@ -82,15 +93,17 @@ export function useCameraAccess(options: CameraAccessOptions = {}): CameraAccess
       logCameraSettings(mediaStream);
     } catch (err) {
       console.error('Camera access error:', err);
+      stopCurrentStream();
       setError('Unable to access camera. Please grant camera permissions.');
       setHasPermission(false);
     }
-  }, []);
+  }, [stopCurrentStream]);
 
   // Start camera on mount if autoStart is true
   useEffect(() => {
     // Only auto-start if autoStart option is true
     if (!autoStart) {
+      stopCurrentStream();
       return;
     }
 
@@ -116,6 +129,7 @@ export function useCameraAccess(options: CameraAccessOptions = {}): CameraAccess
       } catch (err) {
         if (!cancelled) {
           console.error('Camera access error:', err);
+          stopCurrentStream();
           setError('Unable to access camera. Please grant camera permissions.');
           setHasPermission(false);
         }
@@ -127,12 +141,9 @@ export function useCameraAccess(options: CameraAccessOptions = {}): CameraAccess
     // Cleanup on unmount
     return () => {
       cancelled = true;
-      if (streamRef.current) {
-        streamRef.current.getTracks().forEach((track) => track.stop());
-        streamRef.current = null;
-      }
+      stopCurrentStream();
     };
-  }, [autoStart]);
+  }, [autoStart, stopCurrentStream]);
 
   const retry = useCallback(() => {
     startCamera();


### PR DESCRIPTION
## Summary
- stop active app session when browser/PWA is hidden or closed
- ensure audio playback is stopped and app exits active mode on lifecycle events
- harden camera hook cleanup so stream state is cleared whenever camera stops
- add coverage for lifecycle shutdown in App and camera autoStart toggle behavior

## Changes
- add `shutdownExperience` in `App` and wire it to `visibilitychange`, `pagehide`, and `beforeunload`
- include `stop` from `useAudioPlayback` and clear active playback/recognition state during shutdown
- add `stopCurrentStream()` in `useCameraAccess` to consistently stop tracks and clear stream state
- add tests for hidden-state shutdown and `autoStart` false stream shutdown

## Validation
- `npm run pre-commit` ✅
- focused tests:
  - `src/App.playbackFlow.test.tsx`
  - `src/modules/camera-access/useCameraAccess.test.ts`
