### PR TITLE
feat: implement pending concert switch logic for Drop the Needle play…

### DIFF
--- a/src/App.playbackFlow.test.tsx
+++ b/src/App.playbackFlow.test.tsx
@@ -374,6 +374,58 @@ describe('App playback flow', () => {
     expect(screen.getByRole('button', { name: 'Switch to Band Two' })).toBeInTheDocument();
   });
 
+  it('starts the new song via Drop the Needle using crossfade when currently playing', async () => {
+    recognitionState.recognizedConcert = concertOne;
+    audioState.isPlaying = false;
+
+    const user = userEvent.setup();
+    const view = render(<App />);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Activate camera and begin experience',
+      })
+    );
+
+    audioState.isPlaying = true;
+    recognitionState.recognizedConcert = concertTwo;
+    recognitionState.debugInfo = createDebugInfo(concertTwo, 5);
+    view.rerender(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Switch to Band Two' }));
+
+    expect(mockCrossfade).toHaveBeenCalledWith('/audio/two.opus');
+    expect(mockResetRecognition).toHaveBeenCalled();
+  });
+
+  it('starts the new song via Drop the Needle using play when currently paused', async () => {
+    recognitionState.recognizedConcert = concertOne;
+    audioState.isPlaying = false;
+
+    const user = userEvent.setup();
+    const view = render(<App />);
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'Activate camera and begin experience',
+      })
+    );
+
+    audioState.isPlaying = true;
+    recognitionState.recognizedConcert = concertTwo;
+    recognitionState.debugInfo = createDebugInfo(concertTwo, 5);
+    view.rerender(<App />);
+
+    audioState.isPlaying = false;
+    view.rerender(<App />);
+
+    await user.click(screen.getByRole('button', { name: 'Switch to Band Two' }));
+
+    expect(mockPlay).toHaveBeenLastCalledWith('/audio/two.opus');
+    expect(mockCrossfade).not.toHaveBeenCalledWith('/audio/two.opus');
+    expect(mockResetRecognition).toHaveBeenCalled();
+  });
+
   it('closes details and resets recognition when user taps close', async () => {
     recognitionState.recognizedConcert = concertOne;
     audioState.isPlaying = false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,6 +178,7 @@ function AppContent() {
   const [activeConcert, setActiveConcert] = useState<Concert | null>(null);
   const [isConcertInfoVisible, setIsConcertInfoVisible] = useState(false);
   const [hasScannedPhotoLoadFailed, setHasScannedPhotoLoadFailed] = useState(false);
+  const [pendingSwitchConcert, setPendingSwitchConcert] = useState<Concert | null>(null);
   const [dismissedSwitchBand, setDismissedSwitchBand] = useState<string | null>(null);
   const [closedConcertCooldown, setClosedConcertCooldown] = useState<{
     concertId: number;
@@ -410,21 +411,30 @@ function AppContent() {
     setActivePlaylistBand(autoplayConcert.band);
     play(firstSong.audioFile);
     setActiveConcert(firstSong);
+    setPendingSwitchConcert(null);
     setDismissedSwitchBand(null);
   }, [isActive, activeRecognitionConcert, isPlaying, play, activePlaylistBand]);
 
   useEffect(() => {
+    const switchPromptConcert = activeRecognitionConcert;
+
     if (
-      !activeRecognitionConcert ||
+      !switchPromptConcert ||
       !activeConcert ||
-      activeRecognitionConcert.band === activePlaylistBand
+      switchPromptConcert.band === activePlaylistBand ||
+      dismissedSwitchBand === switchPromptConcert.band
     ) {
+      setPendingSwitchConcert(null);
       lastPromptConcertIdRef.current = null;
       promptShownAtRef.current = null;
       return;
     }
 
-    if (lastPromptConcertIdRef.current === activeRecognitionConcert.id) {
+    setPendingSwitchConcert((previousCandidate) =>
+      previousCandidate?.id === switchPromptConcert.id ? previousCandidate : switchPromptConcert
+    );
+
+    if (lastPromptConcertIdRef.current === switchPromptConcert.id) {
       return;
     }
 
@@ -433,14 +443,14 @@ function AppContent() {
     switchDecision.shownCount += 1;
     switchDecision.lastPromptSnapshot = {
       activeConcertId: activeConcert?.id ?? null,
-      candidateConcertId: activeRecognitionConcert.id,
+      candidateConcertId: switchPromptConcert.id,
       confidence: debugInfo?.bestMatch?.similarity ?? null,
       margin: debugInfo?.bestMatchMargin ?? null,
       shownAt,
     };
     promptShownAtRef.current = shownAt;
-    lastPromptConcertIdRef.current = activeRecognitionConcert.id;
-  }, [activeConcert, debugInfo, activeRecognitionConcert, activePlaylistBand]);
+    lastPromptConcertIdRef.current = switchPromptConcert.id;
+  }, [activeConcert, debugInfo, activeRecognitionConcert, activePlaylistBand, dismissedSwitchBand]);
 
   // Clear dismissed switch preference only after a different artist is seen.
   useEffect(() => {
@@ -503,11 +513,12 @@ function AppContent() {
       setActiveConcert(playbackTargetConcert);
     }
 
+    setPendingSwitchConcert(null);
     setDismissedSwitchBand(null);
   };
 
   const handleConfirmSwitch = () => {
-    if (!activeRecognitionConcert) {
+    if (!pendingSwitchConcert) {
       return;
     }
 
@@ -518,10 +529,10 @@ function AppContent() {
     lastPromptConcertIdRef.current = null;
 
     // Build a playlist for the new artist
-    const songs = dataService.getConcertsByBand(activeRecognitionConcert.band);
+    const songs = dataService.getConcertsByBand(pendingSwitchConcert.band);
     const newPlaylist = buildPlaylist(
-      songs.length > 0 ? songs : [activeRecognitionConcert],
-      activeRecognitionConcert.id
+      songs.length > 0 ? songs : [pendingSwitchConcert],
+      pendingSwitchConcert.id
     );
     const firstSong = newPlaylist[0];
     if (!firstSong?.audioFile) {
@@ -538,8 +549,9 @@ function AppContent() {
     userPausedRef.current = false;
     playlistRef.current = newPlaylist;
     playlistIndexRef.current = 0;
-    setActivePlaylistBand(activeRecognitionConcert.band);
+    setActivePlaylistBand(pendingSwitchConcert.band);
     setActiveConcert(firstSong);
+    setPendingSwitchConcert(null);
     setDismissedSwitchBand(null);
     resetRecognition();
   };
@@ -562,6 +574,7 @@ function AppContent() {
       }
 
       setIsConcertInfoVisible(false);
+      setPendingSwitchConcert(null);
       promptShownAtRef.current = null;
       lastPromptConcertIdRef.current = null;
       resetRecognition();
@@ -595,6 +608,7 @@ function AppContent() {
       playlistIndexRef.current = nextIndex;
       setActivePlaylistBand(targetTrack.band);
       setActiveConcert(targetTrack);
+      setPendingSwitchConcert(null);
       setDismissedSwitchBand(null);
       resetRecognition();
     },
@@ -636,6 +650,7 @@ function AppContent() {
     setIsActive(false);
     setIsConcertInfoVisible(false);
     setHasScannedPhotoLoadFailed(false);
+    setPendingSwitchConcert(null);
     setDismissedSwitchBand(null);
     setClosedConcertCooldown(null);
     setActiveConcert(null);
@@ -674,7 +689,9 @@ function AppContent() {
     };
   }, [shutdownExperience]);
 
-  const infoConcert = isConcertInfoVisible ? (activeRecognitionConcert ?? activeConcert) : null;
+  const infoConcert = isConcertInfoVisible
+    ? (pendingSwitchConcert ?? activeRecognitionConcert ?? activeConcert)
+    : null;
   const scannedPhotoUrl = infoConcert?.photoUrl ?? null;
   const shouldShowPhotoPlaceholder =
     !!isConcertInfoVisible && (!scannedPhotoUrl || hasScannedPhotoLoadFailed);
@@ -686,10 +703,7 @@ function AppContent() {
   }, [scannedPhotoUrl]);
 
   const isInfoActive = !!(infoConcert && activeConcert && activeConcert.id === infoConcert.id);
-  const canSwitch =
-    !!activeRecognitionConcert &&
-    !!activeConcert &&
-    activeRecognitionConcert.band !== activePlaylistBand;
+  const canSwitch = !!pendingSwitchConcert;
 
   const statusLabel = playbackError
     ? 'Playback Fault'
@@ -708,7 +722,7 @@ function AppContent() {
       ? playbackError
       : `${playbackError} Check stream access and tap Play to retry.`
     : canSwitch
-      ? `Current cut: ${activeConcert?.band}. Fresh lock found: ${activeRecognitionConcert?.band}.`
+      ? `Current cut: ${activeConcert?.band}. Fresh lock found: ${pendingSwitchConcert?.band}.`
       : activeRecognitionConcert
         ? 'Signal is locked. Playback runs continuously until you pause.'
         : activeConcert


### PR DESCRIPTION
This pull request introduces improvements to the concert switching logic in the app, primarily by adding a new state variable to track pending concert switches and updating the flow to use this variable. This helps ensure that the UI and playback logic respond correctly when the user switches bands, and provides more robust handling of related state transitions. The changes also update tests to cover these scenarios.

Enhancements to concert switching logic:

* Added a new state variable `pendingSwitchConcert` to `AppContent` to track the concert that is pending a switch, ensuring more accurate and reliable state management during band switching.
* Updated the logic in multiple places to use `pendingSwitchConcert` instead of `activeRecognitionConcert` for determining switch eligibility, updating playlists, and displaying concert info, resulting in more consistent behavior and UI updates. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R414-R437) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L521-R535) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L541-R554) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L677-R694) [[5]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L689-R706) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L711-R725)

State cleanup and robustness:

* Ensured `pendingSwitchConcert` is cleared at appropriate times, such as after confirming a switch, closing concert info, switching tracks, or shutting down the experience, to prevent stale state and improve reliability. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R516-R521) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R577) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R611) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R653)

Testing improvements:

* Added two new tests to `App.playbackFlow.test.tsx` to verify that switching bands uses the correct playback method (`crossfade` or `play`) depending on whether audio is currently playing or paused, and that recognition is reset after a switch.

Prompt logic updates:

* Refactored the prompt logic to use `pendingSwitchConcert` and improved the conditions for showing switch prompts, including handling dismissed switches and updating dependencies for the relevant effect hooks. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R414-R437) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L436-R453)…back

## What

<!-- Brief description of what changed -->

## Why

<!-- Why this change is needed. Reference issue if applicable: Closes #123 -->

## How

<!-- Implementation approach and key decisions -->

## Testing

<!-- How was this tested? Include relevant details. -->

- [ ] `npm run pre-commit` passes (lint, format, type-check, tests, build)
- [ ] Tested manually where applicable
- [ ] Confirmed with maintainer whether to pull/merge latest `main` into this branch before handoff (and resolved conflicts if requested)

## Notes

<!-- Anything reviewers should pay attention to: breaking changes, trade-offs, follow-up work, etc. -->
