### PR TITLE
[codex] Fix matched photo layout

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -200,7 +200,8 @@
 .matchedPhotoHeader {
   /* Match cameraWrapPhoto width so content aligns to the photo frame's edges */
   width: max(6rem, min(calc(100vw - 0.5rem), var(--layout-content-max-width)));
-  padding: 0.4rem 0.15rem 0.3rem;
+  padding: 0.35rem 0.15rem 0.2rem;
+  flex-shrink: 0;
 }
 
 .scanAnotherRow {
@@ -208,7 +209,8 @@
   justify-content: flex-end;
   /* Match cameraWrapPhoto width so button aligns to the photo frame's right edge */
   width: max(6rem, min(calc(100vw - 0.5rem), var(--layout-content-max-width)));
-  padding: 0.3rem 0.15rem 0;
+  padding: 0.35rem 0.15rem 0;
+  flex-shrink: 0;
 }
 
 .closePhotoButton {
@@ -245,8 +247,12 @@
 
 .scannedPhotoFrame {
   width: 100%;
+  max-height: inherit;
   position: relative;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: var(--color-background);
   animation: scaleInFade 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
@@ -258,16 +264,11 @@
 }
 
 .scannedPhotoImage {
-  width: 100%;
+  width: auto;
+  max-width: 100%;
   height: auto;
-  /* Fallback for browsers without svh.
-   * 18rem ~= header + signal strip/audio controls + vertical padding/margins.
-   * This keeps the photo within the visible viewport while leaving room for UI.
-   * If header/footer/control heights change (e.g. longer band names wrapping),
-   * update this value to match the new combined UI height. */
-  max-height: max(60vh, calc(100vh - 18rem));
-  /* Preferred: svh excludes browser chrome; uses the same UI offset as above. */
-  max-height: max(60svh, calc(100svh - 18rem));
+  max-height: var(--matched-photo-max-height, calc(100vh - 18rem));
+  max-height: var(--matched-photo-max-height, calc(100svh - 18rem));
   object-fit: contain;
   display: block;
   user-select: none;

--- a/src/modules/gallery-layout/GalleryLayout.module.css
+++ b/src/modules/gallery-layout/GalleryLayout.module.css
@@ -225,10 +225,16 @@
 /* Photo mode — natural aspect ratio, no fixed square height */
 .cameraWrapPhoto {
   width: max(6rem, min(calc(100vw - 0.5rem), var(--layout-content-max-width)));
-  max-height: var(--matched-photo-max-height, calc(100svh - 8rem));
+  max-height: var(--matched-photo-max-height, calc(100vh - 8rem));
   flex: 0 1 auto;
   min-height: 0;
   overflow: hidden;
+}
+
+@supports (height: 100svh) {
+  .cameraWrapPhoto {
+    max-height: var(--matched-photo-max-height, calc(100svh - 8rem));
+  }
 }
 
 .cameraSectionPhoto {
@@ -295,16 +301,21 @@
         var(--matched-photo-audio-clearance) - 10.5rem
     )
   );
-  --matched-photo-max-height: max(
-    7rem,
-    calc(
-      100svh - env(safe-area-inset-top) - env(safe-area-inset-bottom) -
-        var(--matched-photo-audio-clearance) - 10.5rem
-    )
-  );
   gap: var(--matched-photo-gap);
   justify-content: center;
   overflow-y: auto;
+}
+
+@supports (height: 100svh) {
+  .contentMatchedPhoto {
+    --matched-photo-max-height: max(
+      7rem,
+      calc(
+        100svh - env(safe-area-inset-top) - env(safe-area-inset-bottom) -
+          var(--matched-photo-audio-clearance) - 10.5rem
+      )
+    );
+  }
 }
 
 @media (min-width: 768px) {

--- a/src/modules/gallery-layout/GalleryLayout.module.css
+++ b/src/modules/gallery-layout/GalleryLayout.module.css
@@ -164,6 +164,8 @@
 
 /* Content area — camera centered in remaining space */
 .content {
+  --matched-photo-gap: 0.35rem;
+  --matched-photo-audio-clearance: 0rem;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -178,6 +180,7 @@
 }
 
 .contentWithAudio {
+  --matched-photo-audio-clearance: 4.9rem;
   padding-bottom: calc(env(safe-area-inset-bottom) + 3rem);
 }
 
@@ -222,14 +225,15 @@
 /* Photo mode — natural aspect ratio, no fixed square height */
 .cameraWrapPhoto {
   width: max(6rem, min(calc(100vw - 0.5rem), var(--layout-content-max-width)));
-  max-height: calc(100svh - 8rem);
-  flex-shrink: 0;
+  max-height: var(--matched-photo-max-height, calc(100svh - 8rem));
+  flex: 0 1 auto;
+  min-height: 0;
   overflow: hidden;
 }
 
 .cameraSectionPhoto {
   width: 100%;
-  height: auto;
+  max-height: inherit;
   border: 1px solid color-mix(in srgb, var(--color-accent), transparent 60%);
   box-shadow:
     0 0 10px color-mix(in srgb, var(--color-accent), transparent 72%),
@@ -240,7 +244,6 @@
 }
 
 .cameraSectionPhoto > * {
-  height: auto;
   width: 100%;
 }
 
@@ -266,6 +269,7 @@
   }
 
   .contentWithAudio {
+    --matched-photo-audio-clearance: 4.9rem;
     padding-bottom: calc(env(safe-area-inset-bottom) + 3rem);
   }
 }
@@ -277,13 +281,30 @@
 
   .contentWithAudio {
     /* Extra padding ensures the below-photo action row clears the fixed audio strip */
+    --matched-photo-audio-clearance: 6.9rem;
     padding-bottom: calc(env(safe-area-inset-bottom) + 7rem);
   }
 }
 
-/* Matched photo: anchor stack from top so header is never centred off-screen */
+/* Matched photo: center the full header/photo/action stack, then scroll only on truly tiny screens. */
 .contentMatchedPhoto {
-  justify-content: flex-start;
+  --matched-photo-max-height: max(
+    7rem,
+    calc(
+      100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom) -
+        var(--matched-photo-audio-clearance) - 10.5rem
+    )
+  );
+  --matched-photo-max-height: max(
+    7rem,
+    calc(
+      100svh - env(safe-area-inset-top) - env(safe-area-inset-bottom) -
+        var(--matched-photo-audio-clearance) - 10.5rem
+    )
+  );
+  gap: var(--matched-photo-gap);
+  justify-content: center;
+  overflow-y: auto;
 }
 
 @media (min-width: 768px) {

--- a/tests/visual/matched-photo-layout.spec.ts
+++ b/tests/visual/matched-photo-layout.spec.ts
@@ -1,0 +1,278 @@
+import { test, expect, type Page } from '@playwright/test';
+import { safeGrantCameraPermissions } from './utils/camera';
+import { bootstrapVisualState, gotoLanding } from './utils/visual-helpers';
+import type { AppDataV2 } from '../../src/types';
+
+type PhotoAspect = 'landscape' | 'portrait';
+
+interface LayoutCase {
+  name: string;
+  photoAspect: PhotoAspect;
+  viewport: {
+    width: number;
+    height: number;
+  };
+}
+
+const MATCH_DETAILS = {
+  band: 'Overcoats Layout Test',
+  venue: 'Electric Ballroom Test Venue',
+  date: '2026-04-26T21:30:00-05:00',
+  aperture: 'f/2.8',
+  shutterSpeed: '1/250s',
+  iso: '800',
+  focalLength: '35mm',
+};
+
+const MATCHED_STATE_TIMEOUT_MS = 15_000;
+const MATCHED_DATE_TEXT = '2026';
+const MATCHED_EXIF_TEXT = 'ISO 800';
+
+const layoutCases: LayoutCase[] = [
+  {
+    name: 'landscape photo in small portrait viewport',
+    photoAspect: 'landscape',
+    viewport: { width: 360, height: 640 },
+  },
+  {
+    name: 'portrait photo in small portrait viewport',
+    photoAspect: 'portrait',
+    viewport: { width: 360, height: 640 },
+  },
+  {
+    name: 'landscape photo in short landscape viewport',
+    photoAspect: 'landscape',
+    viewport: { width: 844, height: 390 },
+  },
+  {
+    name: 'portrait photo in short landscape viewport',
+    photoAspect: 'portrait',
+    viewport: { width: 844, height: 390 },
+  },
+];
+
+function buildSvgPhotoDataUrl(aspect: PhotoAspect): string {
+  const size = aspect === 'landscape' ? { width: 900, height: 600 } : { width: 600, height: 900 };
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="${size.width}" height="${size.height}" viewBox="0 0 ${size.width} ${size.height}">
+      <rect width="100%" height="100%" fill="#111827"/>
+      <rect x="24" y="24" width="${size.width - 48}" height="${size.height - 48}" fill="#d9c79f"/>
+      <rect x="48" y="48" width="${size.width - 96}" height="${size.height - 96}" fill="#334155"/>
+      <circle cx="${size.width * 0.5}" cy="${size.height * 0.42}" r="${Math.min(size.width, size.height) * 0.18}" fill="#f97316"/>
+      <rect x="${size.width * 0.22}" y="${size.height * 0.68}" width="${size.width * 0.56}" height="${size.height * 0.08}" fill="#f8fafc"/>
+    </svg>
+  `;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+function buildMatchedPhotoPayload(photoAspect: PhotoAspect): AppDataV2 {
+  return {
+    version: 2,
+    artists: [{ id: 'artist-layout-regression', name: MATCH_DETAILS.band }],
+    photos: [
+      {
+        id: 'photo-layout-regression',
+        artistId: 'artist-layout-regression',
+        photoUrl: buildSvgPhotoDataUrl(photoAspect),
+        recognitionEnabled: true,
+        aperture: MATCH_DETAILS.aperture,
+        shutterSpeed: MATCH_DETAILS.shutterSpeed,
+        iso: MATCH_DETAILS.iso,
+        focalLength: MATCH_DETAILS.focalLength,
+      },
+    ],
+    tracks: [
+      {
+        id: 'track-layout-regression',
+        artistId: 'artist-layout-regression',
+        songTitle: 'Regression Test Tone',
+        audioFile: '/test-assets/layout-regression-silence.wav',
+      },
+    ],
+    entries: [
+      {
+        id: 9001,
+        artistId: 'artist-layout-regression',
+        trackId: 'track-layout-regression',
+        photoId: 'photo-layout-regression',
+        venue: MATCH_DETAILS.venue,
+        date: MATCH_DETAILS.date,
+      },
+    ],
+  };
+}
+
+async function routeMatchedPhotoData(page: Page, photoAspect: PhotoAspect): Promise<void> {
+  await page.route('**/data.app.v2.json', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(buildMatchedPhotoPayload(photoAspect)),
+    });
+  });
+
+  await page.route('**/test-assets/layout-regression-silence.wav', async (route) => {
+    const silentWav = Buffer.from(
+      'UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=',
+      'base64'
+    );
+
+    await route.fulfill({
+      contentType: 'audio/wav',
+      body: silentWav,
+    });
+  });
+}
+
+async function forceMatchedPhoto(page: Page): Promise<void> {
+  await gotoLanding(page);
+
+  await page.getByRole('button', { name: /activate camera and begin experience/i }).click();
+  await page.getByRole('button', { name: /open settings/i }).click();
+  await page.getByRole('button', { name: /force a photo match for testing/i }).click();
+
+  await expect(page.locator('html')).toHaveAttribute('data-state', 'matched', {
+    timeout: MATCHED_STATE_TIMEOUT_MS,
+  });
+  await expect(page.getByRole('heading', { name: MATCH_DETAILS.band, level: 2 })).toBeVisible({
+    timeout: MATCHED_STATE_TIMEOUT_MS,
+  });
+  await expect(page.getByText(MATCH_DETAILS.venue)).toBeVisible({
+    timeout: MATCHED_STATE_TIMEOUT_MS,
+  });
+  await expect(page.getByText(MATCHED_DATE_TEXT)).toBeVisible({
+    timeout: MATCHED_STATE_TIMEOUT_MS,
+  });
+  await expect(page.getByText(MATCHED_EXIF_TEXT)).toBeVisible({
+    timeout: MATCHED_STATE_TIMEOUT_MS,
+  });
+
+  const matchedImage = page.getByRole('img', {
+    name: `${MATCH_DETAILS.band} scanned photograph`,
+  });
+  await expect(matchedImage).toBeVisible();
+  await expect
+    .poll(async () => {
+      return matchedImage.evaluate((image) => {
+        if (!(image instanceof HTMLImageElement)) {
+          throw new Error('Matched photo element is not an image.');
+        }
+
+        return image.naturalWidth;
+      });
+    })
+    .toBeGreaterThan(0);
+
+  await expect(
+    page.getByRole('button', { name: /close concert view and scan a new photo/i })
+  ).toBeVisible();
+}
+
+async function expectMatchedLayoutInsideViewport(page: Page): Promise<void> {
+  const metrics = await page.evaluate(
+    ({ bandText, venueText, dateText, exifText }) => {
+      const detailsSection = document.querySelector('section[aria-label="Concert details"]');
+
+      const heading = Array.from(detailsSection?.querySelectorAll('h2') ?? []).find(
+        (element) => element.textContent?.trim() === bandText
+      );
+      const detailParagraphContainingText = (expectedText: string) => {
+        return Array.from(detailsSection?.querySelectorAll('p') ?? []).find((paragraph) =>
+          paragraph.textContent?.includes(expectedText)
+        );
+      };
+
+      const rectForElement = (element: Element | null | undefined) => {
+        if (!element) return null;
+        const rect = element.getBoundingClientRect();
+        return {
+          top: rect.top,
+          right: rect.right,
+          bottom: rect.bottom,
+          left: rect.left,
+          width: rect.width,
+          height: rect.height,
+        };
+      };
+
+      const rects = {
+        heading: rectForElement(heading),
+        venue: rectForElement(detailParagraphContainingText(venueText)),
+        date: rectForElement(detailParagraphContainingText(dateText)),
+        exif: rectForElement(detailParagraphContainingText(exifText)),
+        image: rectForElement(document.querySelector('img[alt*="scanned photograph"]')),
+        scanButton: rectForElement(
+          document.querySelector('button[aria-label="Close concert view and scan a new photo"]')
+        ),
+      };
+
+      return {
+        viewport: {
+          width: window.innerWidth,
+          height: window.innerHeight,
+        },
+        rects,
+      };
+    },
+    {
+      bandText: MATCH_DETAILS.band,
+      venueText: MATCH_DETAILS.venue,
+      dateText: MATCHED_DATE_TEXT,
+      exifText: MATCHED_EXIF_TEXT,
+    }
+  );
+
+  const rects = metrics.rects as Record<
+    string,
+    {
+      top: number;
+      right: number;
+      bottom: number;
+      left: number;
+      width: number;
+      height: number;
+    } | null
+  >;
+
+  for (const [name, rect] of Object.entries(rects)) {
+    expect(rect, `${name} should exist`).not.toBeNull();
+    expect(rect?.width, `${name} should have width`).toBeGreaterThan(0);
+    expect(rect?.height, `${name} should have height`).toBeGreaterThan(0);
+    expect(rect?.top, `${name} should not bleed above viewport`).toBeGreaterThanOrEqual(-0.5);
+    expect(rect?.left, `${name} should not bleed left of viewport`).toBeGreaterThanOrEqual(-0.5);
+    expect(rect?.right, `${name} should not bleed right of viewport`).toBeLessThanOrEqual(
+      metrics.viewport.width + 0.5
+    );
+    expect(rect?.bottom, `${name} should not be cut off below viewport`).toBeLessThanOrEqual(
+      metrics.viewport.height + 0.5
+    );
+  }
+
+  expect(rects.heading!.bottom, 'heading should render above matched photo').toBeLessThanOrEqual(
+    rects.image!.top
+  );
+  expect(
+    rects.exif!.bottom,
+    'all concert info should render above matched photo'
+  ).toBeLessThanOrEqual(rects.image!.top);
+  expect(rects.image!.bottom, 'matched photo should render above scan button').toBeLessThanOrEqual(
+    rects.scanButton!.top
+  );
+}
+
+test.describe('Matched Photo Layout', () => {
+  for (const layoutCase of layoutCases) {
+    test(`@smoke keeps concert info, ${layoutCase.name}, and scan controls visible`, async ({
+      page,
+    }) => {
+      await bootstrapVisualState(page);
+      await safeGrantCameraPermissions(page.context());
+      await page.setViewportSize(layoutCase.viewport);
+      await routeMatchedPhotoData(page, layoutCase.photoAspect);
+
+      await forceMatchedPhoto(page);
+
+      await expectMatchedLayoutInsideViewport(page);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes the matched-photo layout so the concert details, matched image, and scan-another action are centered as a single bounded stack instead of floating into the heading area. The photo now scales within the remaining viewport and preserves aspect ratio for portrait and landscape cases.

## Root cause

Matched-photo mode had a separate top-anchored layout and an overly generous image height cap, unlike the centered live camera state. On constrained screens the photo/result stack could drift upward or overlap controls.

## Validation

- npm run type-check
- npm run build
- pre-commit: lint:fix, format, type-check, module README check, vitest, build, bundle-size check
- Browser probe with real fake-camera recognition sample across portrait and landscape viewports, verifying concert info, matched image, and scan button remain visible and ordered
