### PR TITLE
Fix audio on iOS 16 and earlier: add AAC/M4A fallback

### DIFF
--- a/cloudflare/worker.test.ts
+++ b/cloudflare/worker.test.ts
@@ -330,6 +330,19 @@ describe('Cloudflare worker', () => {
     expect(await response.text()).toBe('');
   });
 
+  it('sets audio/mp4 content type and immutable cache for m4a fallback files', async () => {
+    const env = createEnv({ headResult: { size: 500, etag: 'm4a-etag' } });
+    const response = await worker.fetch(
+      createRequest('/prod/audio/ps-band-song-album.m4a', {
+        headers: { Origin: 'http://localhost:5173' },
+      }),
+      env
+    );
+
+    expect(response.headers.get('Content-Type')).toBe('audio/mp4');
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=31536000, immutable');
+  });
+
   it('sets metadata content headers for non-audio objects', async () => {
     const env = createEnv({ headResult: { size: 123, etag: 'meta' } });
     const response = await worker.fetch(

--- a/cloudflare/worker.ts
+++ b/cloudflare/worker.ts
@@ -152,6 +152,9 @@ function inferContentType(pathname: string) {
   if (pathname.endsWith('.opus')) {
     return DEFAULT_AUDIO_CONTENT_TYPE;
   }
+  if (pathname.endsWith('.m4a')) {
+    return 'audio/mp4';
+  }
   if (pathname.endsWith('.webp')) {
     return 'image/webp';
   }
@@ -176,6 +179,7 @@ function inferContentType(pathname: string) {
 function getCacheControl(pathname: string) {
   if (
     pathname.endsWith('.opus') ||
+    pathname.endsWith('.m4a') ||
     pathname.endsWith('.webp') ||
     pathname.endsWith('.jpg') ||
     pathname.endsWith('.jpeg') ||

--- a/scripts/audio-workflow/encode/encode-audio.js
+++ b/scripts/audio-workflow/encode/encode-audio.js
@@ -338,6 +338,8 @@ async function processAudioFile(download, config, options) {
   const slug = generateSlug(band, title, album);
   const outputFileName = `ps-${slug}.opus`;
   const outputPath = join(outputDir, outputFileName);
+  const aacOutputFileName = `ps-${slug}.m4a`;
+  const aacOutputPath = join(outputDir, aacOutputFileName);
 
   console.log(`  Band:  ${band}`);
   console.log(`  Title: ${title}`);
@@ -355,7 +357,7 @@ async function processAudioFile(download, config, options) {
   console.log(`  Slug:  ${slug}`);
   console.log('');
 
-  if (!dryRun && skipExisting && existsSync(outputPath)) {
+  if (!dryRun && skipExisting && existsSync(outputPath) && existsSync(aacOutputPath)) {
     console.log('  1. Skipping encode (output already exists)');
 
     const existingTrack = existingIndexMap?.get(slug) ?? null;
@@ -491,6 +493,19 @@ async function processAudioFile(download, config, options) {
     },
     bitrateInfo.targetBitrateKbps
   );
+
+  // Step 5b: Encode to AAC/M4A for iOS < 17 fallback (Opus not supported on iOS 16 and earlier)
+  console.log('  5b. Encoding to AAC/M4A (iOS fallback)...');
+  await encodeToAac(fadedWavPath, aacOutputPath, config, {
+    band,
+    title: `${band} — ${date}`,
+    date,
+    album,
+    releaseDate,
+    genre,
+    recordLabel: musicDetails.recordLabel,
+    distributor: musicDetails.distributor,
+  });
 
   // Step 6: Calculate checksum
   console.log('  6. Calculating checksum...');
@@ -921,6 +936,66 @@ function encodeToOpus(inputPath, outputPath, config, metadata, targetBitrateKbps
 
     if (metadata.distributor) {
       args.push('-metadata', `label=${metadata.distributor}`);
+    }
+
+    args.push('-y', outputPath);
+
+    const ffmpeg = spawn('ffmpeg', args, { stdio: 'pipe' });
+    let stderr = '';
+
+    ffmpeg.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    ffmpeg.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`ffmpeg exited with code ${code}: ${stderr}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * Encode to AAC/M4A format — fallback for iOS 16 and earlier which do not support Opus.
+ * Uses ffmpeg's built-in AAC encoder at 192 kbps with -movflags +faststart for web playback.
+ */
+function encodeToAac(inputPath, outputPath, config, metadata) {
+  return new Promise((resolve, reject) => {
+    const defaults = config.metadataDefaults;
+    const albumTag =
+      metadata.album && metadata.album !== 'Unknown Album' ? metadata.album : defaults.album;
+    const genreTag = metadata.genre ?? defaults.genre;
+
+    const args = [
+      '-i',
+      inputPath,
+      '-c:a',
+      'aac',
+      '-b:a',
+      '192k',
+      '-movflags',
+      '+faststart',
+      '-metadata',
+      `title=${metadata.title}`,
+      '-metadata',
+      `artist=${metadata.band}`,
+      '-metadata',
+      `album=${albumTag}`,
+      '-metadata',
+      `date=${metadata.date}`,
+    ];
+
+    if (genreTag) {
+      args.push('-metadata', `genre=${genreTag}`);
+    }
+
+    args.push('-metadata', `copyright=${defaults.copyright}`);
+    args.push('-metadata', `comment=Encoded for Photo Signal`);
+
+    if (metadata.recordLabel) {
+      args.push('-metadata', `publisher=${metadata.recordLabel}`);
     }
 
     args.push('-y', outputPath);

--- a/scripts/audio-workflow/encode/encode-audio.js
+++ b/scripts/audio-workflow/encode/encode-audio.js
@@ -357,8 +357,26 @@ async function processAudioFile(download, config, options) {
   console.log(`  Slug:  ${slug}`);
   console.log('');
 
-  if (!dryRun && skipExisting && existsSync(outputPath) && existsSync(aacOutputPath)) {
-    console.log('  1. Skipping encode (output already exists)');
+  if (!dryRun && skipExisting && existsSync(outputPath)) {
+    if (!existsSync(aacOutputPath)) {
+      // .opus exists but .m4a companion is missing — transcode directly from the existing
+      // .opus without re-running loudness normalization or overwriting the Opus file.
+      console.log('  Skipping Opus encode (already exists); generating missing AAC companion...');
+      await encodeToAac(outputPath, aacOutputPath, config, {
+        band,
+        title: `${band} — ${date}`,
+        date,
+        album,
+        releaseDate,
+        genre,
+        recordLabel: musicDetails.recordLabel,
+        distributor: musicDetails.distributor,
+      });
+      console.log('  ✅ AAC companion generated');
+      console.log('');
+    } else {
+      console.log('  1. Skipping encode (output already exists)');
+    }
 
     const existingTrack = existingIndexMap?.get(slug) ?? null;
     if (existingTrack) {

--- a/scripts/audio-workflow/update/__tests__/upload-to-r2.test.js
+++ b/scripts/audio-workflow/update/__tests__/upload-to-r2.test.js
@@ -127,6 +127,8 @@ describe('upload-to-r2 helpers', () => {
   it('returns accurate content types and cache headers', () => {
     expect(getContentType('/tmp/file.opus')).toBe('audio/ogg; codecs=opus');
     expect(getCacheControl('/tmp/file.opus')).toContain('31536000');
+    expect(getContentType('/tmp/file.m4a')).toBe('audio/mp4');
+    expect(getCacheControl('/tmp/file.m4a')).toContain('31536000');
     expect(getContentType('/tmp/photo.jpg')).toBe('image/jpeg');
     expect(getCacheControl('/tmp/photo.jpg')).toContain('31536000');
     expect(getContentType('/tmp/data.json')).toBe('application/json; charset=utf-8');

--- a/scripts/audio-workflow/update/upload-to-r2.js
+++ b/scripts/audio-workflow/update/upload-to-r2.js
@@ -10,6 +10,7 @@ import { loadProjectEnv } from './load-local-env.js';
 const DEFAULT_INPUT_DIR = 'scripts/audio-workflow/encode/output';
 const DEFAULT_INCLUDE_EXTENSIONS = [
   '.opus',
+  '.m4a',
   '.webp',
   '.jpg',
   '.jpeg',
@@ -208,6 +209,8 @@ export function getContentType(filePath) {
   switch (ext) {
     case '.opus':
       return 'audio/ogg; codecs=opus';
+    case '.m4a':
+      return 'audio/mp4';
     case '.webp':
       return 'image/webp';
     case '.jpg':
@@ -229,7 +232,7 @@ export function getContentType(filePath) {
 
 export function getCacheControl(filePath) {
   const ext = path.extname(filePath).toLowerCase();
-  if (['.opus', '.webp', '.jpg', '.jpeg', '.png', '.avif'].includes(ext)) {
+  if (['.opus', '.m4a', '.webp', '.jpg', '.jpeg', '.png', '.avif'].includes(ext)) {
     return 'public, max-age=31536000, immutable';
   }
   return 'public, max-age=300';

--- a/src/modules/audio-playback/useAudioPlayback.test.ts
+++ b/src/modules/audio-playback/useAudioPlayback.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { Howl, Howler } from 'howler';
-import { useAudioPlayback } from './useAudioPlayback';
+import { useAudioPlayback, buildAudioSrc } from './useAudioPlayback';
 
 // Mock diagnoseAudioUrl
 vi.mock('./diagnoseAudioUrl', () => ({
@@ -191,6 +191,27 @@ const createDeferred = () => {
   return { promise, resolve };
 };
 
+describe('buildAudioSrc', () => {
+  it('returns [opusUrl, aacUrl] for .opus sources', () => {
+    expect(buildAudioSrc('/audio/ps-band-song.opus')).toEqual([
+      '/audio/ps-band-song.opus',
+      '/audio/ps-band-song.m4a',
+    ]);
+  });
+
+  it('returns a single-element array for non-.opus sources', () => {
+    expect(buildAudioSrc('/audio/track.mp3')).toEqual(['/audio/track.mp3']);
+    expect(buildAudioSrc('/audio/track.m4a')).toEqual(['/audio/track.m4a']);
+  });
+
+  it('replaces only the .opus extension, not occurrences within the path', () => {
+    expect(buildAudioSrc('/opus-files/ps-band.opus')).toEqual([
+      '/opus-files/ps-band.opus',
+      '/opus-files/ps-band.m4a',
+    ]);
+  });
+});
+
 describe('useAudioPlayback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -242,6 +263,29 @@ describe('useAudioPlayback', () => {
       });
 
       expect(getMockedHowlClass().instances[0].options.html5).toBe(false);
+    });
+
+    it('should pass [opusUrl, aacUrl] to Howler for .opus sources (iOS 16 fallback)', () => {
+      const { result } = renderHook(() => useAudioPlayback());
+
+      act(() => {
+        result.current.play('/audio/ps-band-song.opus');
+      });
+
+      expect(getMockedHowlClass().instances[0].options.src).toEqual([
+        '/audio/ps-band-song.opus',
+        '/audio/ps-band-song.m4a',
+      ]);
+    });
+
+    it('should pass a single-element src array to Howler for non-.opus sources', () => {
+      const { result } = renderHook(() => useAudioPlayback());
+
+      act(() => {
+        result.current.play('/audio/track.mp3');
+      });
+
+      expect(getMockedHowlClass().instances[0].options.src).toEqual(['/audio/track.mp3']);
     });
 
     it('should use correct volume when playing', () => {

--- a/src/modules/audio-playback/useAudioPlayback.ts
+++ b/src/modules/audio-playback/useAudioPlayback.ts
@@ -319,8 +319,11 @@ export function useAudioPlayback(options: AudioPlaybackOptions = {}): AudioPlayb
 
   const createSound = useCallback(
     (url: string, { initialVolume }: { initialVolume?: number } = {}) => {
+      // Provide an AAC/M4A fallback so Howler picks it on iOS 16 and earlier,
+      // which do not support Opus. Howler tries src[0] first and falls back automatically.
+      const src = url.endsWith('.opus') ? [url, url.replace(/\.opus$/, '.m4a')] : [url];
       const sound = new Howl({
-        src: [url],
+        src,
         // Use Howler's Web Audio path so a single unlocked audio context
         // governs playback across track changes on mobile browsers.
         html5: false,

--- a/src/modules/audio-playback/useAudioPlayback.ts
+++ b/src/modules/audio-playback/useAudioPlayback.ts
@@ -5,6 +5,16 @@ import { diagnoseAudioUrl } from './diagnoseAudioUrl';
 
 const { Howl } = howlerModule;
 
+/**
+ * Returns the Howler src array for a given URL.
+ * Opus URLs get an AAC/M4A fallback appended so iOS 16 and earlier (which do not support
+ * Opus) automatically fall back to the companion file. Howler picks the first playable
+ * format at init time, so modern browsers still use Opus.
+ */
+export function buildAudioSrc(url: string): string[] {
+  return url.endsWith('.opus') ? [url, url.replace(/\.opus$/, '.m4a')] : [url];
+}
+
 function getHowlerContext(): { state?: string; resume?: () => Promise<unknown> } | undefined {
   try {
     const howler = Reflect.get(howlerModule as object, 'Howler') as
@@ -204,6 +214,7 @@ export function useAudioPlayback(options: AudioPlaybackOptions = {}): AudioPlayb
 
   const attachCallbacks = useCallback(
     (sound: Howl, url: string) => {
+      const src = buildAudioSrc(url);
       const hasEventApi = typeof sound.on === 'function' && typeof sound.off === 'function';
 
       const onPlay = () => {
@@ -231,7 +242,9 @@ export function useAudioPlayback(options: AudioPlaybackOptions = {}): AudioPlayb
 
       const onLoadError = (_id: number, error: unknown) => {
         console.error('[Audio] Load error:', error);
-        console.warn('[Audio] File not found:', url);
+        // Log all sources so it's clear which URL(s) Howler exhausted.
+        // When a fallback is present, the last entry is the one Howler actually fetched.
+        console.warn('[Audio] Sources tried:', src);
         if (soundRef.current === sound) {
           stopProgressLoop();
           setIsPlaying(false);
@@ -240,9 +253,11 @@ export function useAudioPlayback(options: AudioPlaybackOptions = {}): AudioPlayb
           // Clear refs and unload to enable clean retry
           cleanupSound(sound, url);
 
-          // Asynchronously replace generic message with diagnostic details.
-          // Only update error state if a different URL hasn't been loaded since.
-          startDiagnostic(url)
+          // Diagnose the last source in the array — when a fallback exists (e.g. .m4a),
+          // that is the URL Howler actually fetched last, so it's the one most likely to
+          // surface the real error (e.g. a 404 during CDN rollout of the new format).
+          const diagnosticUrl = src[src.length - 1];
+          startDiagnostic(diagnosticUrl)
             .then((result) => {
               // If mounted and no other URL has been loaded (or same URL loaded again), update
               if (
@@ -319,11 +334,8 @@ export function useAudioPlayback(options: AudioPlaybackOptions = {}): AudioPlayb
 
   const createSound = useCallback(
     (url: string, { initialVolume }: { initialVolume?: number } = {}) => {
-      // Provide an AAC/M4A fallback so Howler picks it on iOS 16 and earlier,
-      // which do not support Opus. Howler tries src[0] first and falls back automatically.
-      const src = url.endsWith('.opus') ? [url, url.replace(/\.opus$/, '.m4a')] : [url];
       const sound = new Howl({
-        src,
+        src: buildAudioSrc(url),
         // Use Howler's Web Audio path so a single unlocked audio context
         // governs playback across track changes on mobile browsers.
         html5: false,


### PR DESCRIPTION
## Summary

- **Root cause**: Opus (`audio/ogg; codecs=opus`) is not supported on iOS Safari until iOS 17 (September 2023). On iOS 16 and earlier, `AudioContext.decodeAudioData()` fails silently, the `loaderror` event fires, and the user sees "Audio failed to load" with no sound.
- **Fix**: Encode a companion AAC/M4A file alongside every Opus file, and pass both URLs to Howler (`src: [opusUrl, aacUrl]`). Howler probes codec support at init time and picks the first playable format — iOS ≥17 and all other browsers use Opus as before; iOS ≤16 transparently falls back to AAC.
- **No data model change**: The fallback URL is derived at runtime by replacing `.opus` → `.m4a`, so no JSON changes or data regeneration are needed.

## Changes

| File | What changed |
|------|-------------|
| `scripts/audio-workflow/encode/encode-audio.js` | New step 5b: encode faded WAV → AAC/M4A at 192 kbps with `-movflags +faststart`. Skip-existing now requires both `.opus` **and** `.m4a` to be present, so existing tracks get their companions on the next encode run. |
| `scripts/audio-workflow/update/upload-to-r2.js` | Add `.m4a` to default include extensions, `getContentType` (`audio/mp4`), and immutable cache list. |
| `cloudflare/worker.ts` | Serve `.m4a` as `audio/mp4` with `Cache-Control: public, max-age=31536000, immutable`. |
| `src/modules/audio-playback/useAudioPlayback.ts` | Pass `[opusUrl, aacUrl]` to `new Howl()` when URL ends in `.opus`. |
| Tests | New assertions for `.m4a` content type + cache control in both the worker and upload-to-r2 test suites. |

## Action required after merge

Run the audio workflow to produce and upload the `.m4a` companions for all existing tracks:

```bash
npm run encode-audio   # re-runs encode; skips .opus if already present, generates .m4a companions
npm run upload-audio   # uploads new .m4a files to R2
```

Once the `.m4a` files are live on the CDN, iOS ≤16 users will hear audio immediately on their next visit.

## Test plan

- [ ] `npm run pre-commit` passes (lint, type-check, 55 test files, build, bundle size)
- [ ] After running the audio workflow: verify a `.m4a` file exists alongside each `.opus` in R2
- [ ] On iOS 16 (or Safari with Opus disabled via Web Inspector): confirm audio plays via AAC fallback
- [ ] On iOS 17+ / Android / desktop: confirm Opus still plays (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)