### PR TITLE
linkedin: rewrite posts 2–4 with two distinct drafts each

### DIFF
--- a/linkedin/media-plan.md
+++ b/linkedin/media-plan.md
@@ -29,31 +29,38 @@ Hiring managers, engineering leads, and product-minded engineers at companies do
 
 ## Multimedia (to capture before posting)
 
+**Important: LinkedIn does not allow mixing images and video in the same post.** Choose one media type per post — either a single image/carousel of images, or a single video/GIF. Plan accordingly.
+
 ### Post 1
 
-- 2–3 photos of the bathroom gallery wall: the printed photos, frames, the scale and feel of the space
-- A short video or GIF (10–20 sec): hold phone to a print → UI matches → song starts
-- Wider shot showing the full gallery feel if possible
+- **Recommended**: 2–3 photos of the bathroom gallery wall as a carousel — the printed photos, the frames, the feel of the space. The intimacy is the point.
+- **Alternative**: Short video (10–20 sec): hold phone to a print → UI matches → song starts. If you go video, post a single clip (no carousel mix).
+- **Difficulty**: Easy — you have the space, take the shots.
 
 ### Post 2
 
-- Screen recording GIF (15–30 sec) of a Claude Code session: agent reading code, writing a diff, terminal showing tests passing
-- OR: screenshot of the CI pipeline with all 7 checks green
+- **Recommended**: Screenshot of the CI pipeline with all 7 checks green — label the steps if legible: lint, format, type-check, README sync, tests, build, bundle size. Single image. Easy to capture next clean CI run.
+- **Alternative**: Screen recording GIF (15–20 sec) of a Claude Code session: agent reading code, writing a diff, terminal showing tests passing. Moderate — need to deliberately record a session.
+- **Difficulty**: Easy (CI screenshot) or Moderate (Claude Code GIF).
+- **Note**: Save the recognition GIF for Post 3 — don't split the attention.
 
 ### Post 3
 
-- GIF of recognition in action: phone moves across the wall → UI searches → snaps to match → song info appears
-- Optional: side-by-side of the same print under different lighting (shows why multi-exposure matters)
+- **Recommended**: GIF of recognition in action — phone panning slowly across the gallery wall, UI in search mode, then snapping to match, song info appears. 15–25 seconds. Single GIF.
+- **Alternative**: If you can capture the same print under meaningfully different lighting (warm overhead vs. cooler ambient) in a clean side-by-side photo, that's a strong second option. Hard to set up deliberately.
+- **Difficulty**: Moderate (recognition GIF — requires screen-recording the phone while someone holds it to the wall) or Hard (side-by-side lighting).
+- **Note**: Do not use a carousel mixing images + the GIF. Choose one type.
 
 ### Post 4
 
-- Best hero image from the full series: phone held to the gallery wall, song playing on screen, the whole experience in one frame
-- This should feel definitive — the one shot that captures everything
+- **Recommended**: Single strong static photo — gallery wall with prints visible, or phone held to a print with the matched UI on screen. The still image should feel final and calm. This post is about the person, not the technology.
+- **Do not use a GIF here** — Post 3 owns the motion. Post 4 should feel still.
+- **Difficulty**: Easy — you already have this from Post 1 prep.
 
 ## Format Rules (all posts)
 
 - **Length**: 150–250 words. Long enough to have substance, short enough to read standing up.
-- **Tone**: Posts 1 and 4 are narrative — no bullet lists, written like a person thinking. Posts 2 and 3 can use 2–3 tight bullets for technical content.
+- **Tone**: All posts are narrative — no bullet lists, written like a person thinking. Same voice as Post 1 across all four.
 - **Multimedia**: Every post. Non-negotiable. LinkedIn's algorithm deprioritizes text-only posts.
 - **Hashtags**: 4 max per post. Listed in each post doc.
 - **Closing**: Each post ends with a question or soft invitation — something that opens a reply thread.

--- a/linkedin/post-2-the-process.md
+++ b/linkedin/post-2-the-process.md
@@ -18,30 +18,55 @@
 
 ---
 
-## Draft
+## Draft A — The Journey (chronological)
 
-I didn't write the code. Here's what I did instead.
+I started this project once before.
 
-Claude Code and GitHub Copilot handled all the implementation on Photo Signal — every component, every hook, every test. Multiple AI agents ran in parallel, each in an isolated git branch with its own dev server port so they never stepped on each other.
+Sometime in 2025. A few weeks in. The AI could build — components, hooks, tests, all of it. Genuinely impressive. But the output felt like it was made by someone who had never heard the music.
+
+I shelved it.
+
+Picked it up again this year. Something had shifted. Meaningfully better in ways that are hard to quantify and easy to feel. The first version felt like scaffolding. This one felt like a project.
 
 My job looked like this:
 
-— Write precise specs. Vague requirements produce vague code. I learned to be exact.
-— Review every PR the agents opened. Read for correctness, performance, and whether it matched the intent.
-— Hold the quality bar. Every commit — human or agent — clears the same 7-step gate: lint, format, type-check, module README sync, tests, build, bundle size. No exceptions. No skipping.
-— Make the calls the agents can't make. The biggest one: no QR codes. The prints had to work unmodified, under variable gallery lighting. That one call shaped the entire recognition architecture.
+I made calls. No QR codes — the prints had to work unmodified, under variable gallery lighting. That one decision shaped the entire recognition architecture.
 
-This isn't "AI wrote my code for me." It's closer to leading a team where every engineer ships fast, never complains, and needs you to know exactly what you want.
+I chose tooling I had never used. pHash, Cloudflare Workers, Vite. None of them. I read enough to think they were probably right, and if I was wrong I could change it. It's an art project in my bathroom. Two-way door. I didn't lose sleep.
 
-The bottleneck shifted from implementation to clarity of thought. That's a different skill. I think it's the more durable one.
+The CI gate enforces the quality bar — seven steps, every commit, no exceptions. One of them is a custom script that checks whether every exported function in every module has documentation in that module's README. Agents commit. The check runs too.
 
-Curious whether others are finding the same — where's the friction in your AI-assisted workflow?
+And I kept writing the same note into every prompt: add more of me into it.
+
+Not "make it more polished." The unmatched state should look like analog TV static — I named it dead signal. The color palette for each concert is derived from the band name and the day of the week, hashed deterministically. The scan lines fade back in as a song nears its end. These weren't requirements. They were creative instructions I had to repeat until they stuck.
+
+That's the actual job. Know enough to have an opinion. Be stubborn about the right things. Recognize when the stakes are low enough to just try something.
+
+---
+
+## Draft B — The Instruction (thesis-first)
+
+Every prompt I wrote for this project had the same note somewhere in it: add more of me into it.
+
+It sounds vague. It took months to operationalize.
+
+Not "improve the UI." Not "add more polish." The unmatched state should have a name — I called it dead signal — and it should look like analog static. The color palette for each concert should be derived from the band name and day of the week: FNV-1a hash of the artist, each day owns a 51° arc of the color wheel, accent offset by the golden angle. The CRT phosphor glow is a specific amber, not a default. As a song nears its end, the scan lines fade back in — the broadcast signal fades with it. The EXIF data from the original concert photos drives film grain: higher ISO, more noise in the matched UI.
+
+None of this came from the AI. It came from me saying the same thing until it stuck.
+
+I'd started this project once before, in 2025. Put it down. The AI could build — everything it was asked to. But the result felt like it was made by someone who had never heard the music. Picked it back up this year. Something had shifted. The first version felt like scaffolding. This one felt like a project.
+
+The infrastructure: I chose tooling I had never used. pHash, Cloudflare Workers, Vite. Read enough to think they were probably right. It's an art project in my bathroom — if I was wrong, I could change it. Two-way door. I didn't lose sleep.
+
+The job isn't prompting. It's knowing what you want clearly enough to keep asking for it until you get it.
 
 ---
 
 ## Notes
 
-- The 7-step pre-commit gate is a concrete detail that signals real engineering discipline. It's not marketing language — every commit actually clears it.
-- The "no QR codes" decision is the best example of a product call that shaped the whole system. It shows you don't just direct implementation — you make architectural decisions.
-- The closing question is intentional. Engineers who've worked with AI tools will have opinions. That's a comment thread.
+- **Draft A** opens with the timeline — good for readers who respond to narrative arc and the "trying to figure it out" story. More personal, more journey.
+- **Draft B** opens with the central insight ("add more of me") — good if you want to lead with what's most distinctive and let the timeline be supporting evidence. More philosophical.
+- Both drafts remove bullet points to match Post 1's voice.
+- Real codebase details used: `dead signal` (actual state name in code), the module README sync CI step, the FNV-1a hash / 51° day arc / golden angle for color palettes, EXIF-driven film grain, scan lines fading with song progress.
+- The 7-step gate is real; the module README sync step is the most unusual one — signals that docs are enforced, not aspirational.
 - Don't editorialize about AI replacing developers. Keep it grounded in your specific experience on this specific project.

--- a/linkedin/post-2-the-process.md
+++ b/linkedin/post-2-the-process.md
@@ -28,7 +28,7 @@ I shelved it.
 
 Picked it up again this year. Something had shifted. Meaningfully better in ways that are hard to quantify and easy to feel. The first version felt like scaffolding. This one felt like a project.
 
-My job looked like this:
+My job looked like this.
 
 I made calls. No QR codes — the prints had to work unmodified, under variable gallery lighting. That one decision shaped the entire recognition architecture.
 

--- a/linkedin/post-3-the-engineering.md
+++ b/linkedin/post-3-the-engineering.md
@@ -56,7 +56,7 @@ The recognition runs in a Web Worker. The main thread never sees it. Check inter
 
 At the moment of match, the rectangle overlay's bloom animation fires. The concert color palette — derived from the band name and day of the week — replaces the amber dead-signal ambient. The song starts.
 
-The app also occasionally glitches. Red channel shifts a few pixels left, blue shifts right. Chromatic aberration. Fires at about 0.3% per animation frame — roughly once every five minutes. The TV hasn't been fully repaired.
+The app also occasionally glitches. Red channel shifts a few pixels left, blue shifts right. Chromatic aberration. Fires at about 0.3% per second — roughly once every five minutes. The TV hasn't been fully repaired.
 
 ---
 
@@ -66,7 +66,7 @@ The app also occasionally glitches. Red channel shifts a few pixels left, blue s
 - **Draft B** starts from what the user experiences and works inward — more accessible, still technically specific. The ending (stochastic glitch, "TV hasn't been fully repaired") adds personality.
 - **The threshold is 18 bits, not 14.** The original draft had this wrong. Both new drafts use the correct number.
 - The secondary candidate gap (5 bits worse) is a real implementation detail — signals the system actively avoids false positives, not just low-threshold matching.
-- The stochastic glitch is real: `@keyframes chromaticShift`, fires at 0.3% per rAF tick, roughly once every 5 minutes.
+- The stochastic glitch is real: `@keyframes chromaticShift`, fires at 0.3% per second on a 1-second `setInterval` tick, roughly once every 5 minutes.
 - The multi-exposure insight (dark/normal/bright variants, minimum Hamming distance) is the genuinely clever part. Don't undersell it — it's lighting robustness without ML.
 - Don't go into DCT math or homography. The depth is in the specifics, not the formulas.
 - Engineers in the comments may ask about false positives, dataset size, or performance. Be ready to discuss. The repo is public — invite them to look.

--- a/linkedin/post-3-the-engineering.md
+++ b/linkedin/post-3-the-engineering.md
@@ -18,32 +18,55 @@
 
 ---
 
-## Draft
+## Draft A — Constraint drives design
 
-Recognizing ~100 printed photographs under gallery lighting is a harder problem than it sounds.
+Gallery lighting is messy. Overhead fixtures, shadows, angles, color temperature. I knew this going in.
 
-Gallery lighting is messy. Overhead fixtures, directional lamps, shadows, angles. A QR code approach would have worked — but QR codes require modifying the prints. I didn't want that. The photos had to stand on their own, as photographs.
+But the real constraint wasn't lighting. It was the photographs.
 
-So the constraint drove the design.
+I didn't want to modify the prints. No QR codes, no invisible markers. These were photographs from concerts I actually went to. They had to stand as photographs. The technology had to work around that, not the other way around.
 
-The solution uses perceptual hashing (pHash) — a 64-bit fingerprint derived from the visual structure of an image, not its exact pixels. Similar-looking images produce similar hashes. Distance between hashes is measurable.
+So: perceptual hashing. Each print gets a 64-bit fingerprint based on visual structure — not exact pixels. Similar images produce similar hashes. Measure the distance between them.
 
-The wrinkle: gallery lighting shifts the apparent brightness of every print. A photo under a warm overhead lamp hashes differently than the same photo in cooler light. Solve that wrong and recognition breaks constantly.
+The wrinkle: the same print under different lighting hashes differently. A warm overhead lamp shifts the apparent brightness of everything on the wall. Solve that wrong and recognition breaks constantly.
 
-The fix: pre-compute three hash variants per print — dark, normal, and bright exposure. At runtime, match against all three and take the minimum distance. Lighting robustness without a neural network.
+Fix: pre-compute three hash variants per print — dark, normal, bright — at build time. At runtime, match against all three and take the minimum Hamming distance. Lighting robustness without a neural network.
 
-It runs in a Web Worker, never on the main thread. Adaptive check interval: ~80ms when tracking a candidate, ~120ms idle. The UI never competes with the recognition pipeline.
+Threshold: 18 out of 64 bits. A secondary candidate has to be at least 5 bits worse than the best match. Dialed in on real prints, in the actual gallery, under the actual lights.
 
-Threshold: 14 out of 64 bits (~78% similarity). Tuned empirically on real prints under real gallery conditions.
+The check runs in a Web Worker — never on the main thread. ~80ms while tracking a candidate, ~120ms idle.
 
-The easy path was QR codes. The interesting path was solving the actual problem. I'm glad we took the interesting one.
+The easy path was QR codes. But that would have made it a different project.
+
+---
+
+## Draft B — From the user's experience inward
+
+You point your phone at a print. The app finds it in about a second.
+
+That sounds simple. Here's why it isn't.
+
+Gallery lighting is inconsistent. The same photo under a warm overhead lamp looks meaningfully different from the same photo in a cool corner. A recognition approach that works in one spot can fail two feet to the left. And I wasn't going to put QR codes on the prints — these were photographs. They had to stand as photographs.
+
+The solution uses perceptual hashing: a 64-bit fingerprint derived from the visual structure of an image, not its exact pixels. Similar-looking images produce similar hashes. Measure the distance. Take the nearest match.
+
+The lighting problem needed a specific fix: three hash variants per print — dark, normal, bright — computed at build time. At runtime, match against all three and use the minimum distance. The match threshold is 18 out of 64 bits, with a required gap of at least 5 bits over the next closest candidate.
+
+The recognition runs in a Web Worker. The main thread never sees it. Check interval adapts: ~80ms while tracking a candidate, ~120ms idle.
+
+At the moment of match, the rectangle overlay's bloom animation fires. The concert color palette — derived from the band name and day of the week — replaces the amber dead-signal ambient. The song starts.
+
+The app also occasionally glitches. Red channel shifts a few pixels left, blue shifts right. Chromatic aberration. Fires at about 0.3% per animation frame — roughly once every five minutes. The TV hasn't been fully repaired.
 
 ---
 
 ## Notes
 
-- The numbers are real: 14/64 Hamming distance threshold, 80ms/120ms adaptive interval. Specificity signals credibility.
-- "The constraint drove the design" is a line worth keeping verbatim — it's the core engineering principle and it reads well.
+- **Draft A** leads with the constraint — good for readers who appreciate the product/architecture reasoning. Engineering story told from the builder's perspective.
+- **Draft B** starts from what the user experiences and works inward — more accessible, still technically specific. The ending (stochastic glitch, "TV hasn't been fully repaired") adds personality.
+- **The threshold is 18 bits, not 14.** The original draft had this wrong. Both new drafts use the correct number.
+- The secondary candidate gap (5 bits worse) is a real implementation detail — signals the system actively avoids false positives, not just low-threshold matching.
+- The stochastic glitch is real: `@keyframes chromaticShift`, fires at 0.3% per rAF tick, roughly once every 5 minutes.
 - The multi-exposure insight (dark/normal/bright variants, minimum Hamming distance) is the genuinely clever part. Don't undersell it — it's lighting robustness without ML.
-- Don't go into DCT math or homography. This post should be readable by a senior PM. The depth is in the specifics, not the formulas.
+- Don't go into DCT math or homography. The depth is in the specifics, not the formulas.
 - Engineers in the comments may ask about false positives, dataset size, or performance. Be ready to discuss. The repo is public — invite them to look.

--- a/linkedin/post-4-the-case.md
+++ b/linkedin/post-4-the-case.md
@@ -19,35 +19,50 @@
 
 ---
 
-## Draft
+## Draft A — The Callback (warm, retrospective)
 
-I've been thinking about why this project felt natural to build — and what it says about the role I'm looking for next.
+A few weeks ago a photo of my bathroom went modestly viral.
 
-Long background in CS and engineering. More recently: product management and ownership — running roadmaps, sitting between the technical team and the people the product serves. And separately, genuine interest in art, photography, music, and how software makes people feel.
+What I keep coming back to is what the project taught me about the role.
 
-For a long time those tracks felt separate.
+I've spent enough time in product to know that good engineering is mostly taste — knowing what matters, knowing when it's done, knowing the difference between a feature that ships and one that solves the problem. I've spent enough time as an engineer to be useful: I'll pick up tooling I don't know, read enough to form an opinion, and make the call.
 
-Photo Signal pulled them together. The art concept came first. The technology was built to serve it. And the AI tooling made it possible for one person to hold the whole thing — vision, constraints, direction, quality bar, aesthetic decisions, human judgment.
+This project ran the full arc. Art concept → architectural calls (no QR codes; chose pHash, Cloudflare Workers, Vite without having used any of them) → recognition algorithm → seven-step CI gate → the aesthetic direction I kept pushing on: add more of me into it.
 
-That last part — human judgment — is the part that doesn't get automated away.
+The EXIF data from the original concert photos — ISO, shutter speed, aperture — drives the visual character of each matched UI. Higher ISO means more film grain. The camera that took the photo shapes how the app looks when you find it. No one asked for that. I kept asking for it until it was there.
 
-Knowing what good looks like. Caring whether the experience feels right. Tasting the difference between a feature that ships and a feature that actually solves the problem.
+What AI-assisted development surfaces clearly: you still need someone who cares whether the outcome is right. Someone with taste. Someone willing to be stubborn about the right things.
 
-The role I want: product engineer. Delivering features end-to-end. Working alongside brilliant architects who design the foundation, so I can focus on the specific problems users actually have. On a team that's proud of what it builds together.
+I want to work on a team that's building something they're proud of. If that's yours, I'd love to hear what you're working on.
 
-At this level of abstraction, that combination — CS roots, product ownership experience, and genuine taste — is rarer than it should be.
+The repo is public. The bathroom gallery is real.
 
-If you're building something you're proud of and looking for someone like this, I'd love to talk.
+---
 
-The skill isn't prompting. It's knowing what good looks like — and caring enough to get there.
+## Draft B — The Honest Assessment (direct, slightly contrarian)
+
+The hardest thing to explain about this kind of work: I care whether it feels right.
+
+Not "is it shipped." Not "does it pass CI" — though it does, all seven steps. Whether the thing you made matches what you intended. Whether the detail no one will notice was still worth getting right.
+
+That instinct drove every significant decision on this project. No QR codes — not because they wouldn't work, but because they'd change what the photographs were. Three hash variants per print so the same photo recognizes correctly under a warm spotlight and in a cool corner. A stochastic glitch that fires roughly once every five minutes — because an app that never glitches doesn't feel like a real piece of hardware.
+
+I directed AI agents across the full stack. Chose tooling I had never worked with — pHash, Cloudflare Workers, Vite — because I read enough to think they were probably right, and it's an art project in my bathroom. Wrong call? Change it. Two-way door.
+
+Started this in 2025 and shelved it. The AI could build, but the output felt generic. Came back in 2026 when the tools had caught up to what I was actually trying to make.
+
+What the role looks like, at its best: product instinct and engineering judgment in conversation, not siloed. I want to work somewhere building something worth caring about.
+
+If that's your team, I'd genuinely like to talk.
 
 ---
 
 ## Notes
 
-- This post is the close. It should feel earned — three posts of concrete evidence, then this.
-- "Human judgment" and "taste" are the differentiators. Name them without hedging.
-- The role description is specific on purpose: "alongside brilliant architects," "features end-to-end," "proud of what it builds together." These are signals to the right kind of hiring manager.
-- Don't list technologies. Don't moralize about AI. Keep it grounded in your specific experience.
-- "I'd love to talk" is the call to action. Keep it low-pressure — the right people will reach out.
-- After posting: pin a comment with the repo link if it's not in the post body. Let the code speak for itself to anyone who wants to go deeper.
+- **Draft A** is warm and retrospective — ties back to the bathroom viral moment, uses "add more of me" as a throughline from Post 2. Good close for a narrative series.
+- **Draft B** is more direct and slightly contrarian — opens with a provocation about taste, uses the project as evidence. Good if you want to end with more conviction.
+- Both drafts drop the resume-style background summary ("Long background in CS...") — that language reads like a cover letter.
+- EXIF-driven film grain is a real detail (ISO → grain opacity 0.06–0.28 in code). It's the kind of thing that signals someone cared about craft.
+- The stochastic glitch appears in both drafts as a concrete example of taste — choosing to add organic imperfection.
+- "I'd love to talk" / "I'd genuinely like to talk" — keep it low-pressure. The right people will reach out.
+- After posting: pin a comment with the repo link. Let the code speak for itself.


### PR DESCRIPTION
## Summary

- **Posts 2, 3, and 4** each now have two distinctly different drafts (A and B) to pick from and mix-and-match before posting
- Voice brought in line with Post 1 — narrative, no bullet-point frameworks, no defensive framing
- Real codebase details woven into copy to make it feel authentic rather than generic

## What changed per file

**`linkedin/post-2-the-process.md`**
- Draft A (Journey): Opens with the 2025 attempt that felt sterile, shelving it, coming back in 2026. Chronological; "add more of me into it" lands near the end.
- Draft B (Instruction): Opens with "add more of me" as the thesis, backs into the timeline. Leads with the most distinctive insight.
- Both drafts reference real project details: `dead signal` state name, the module README sync CI step, FNV-1a palette hashing / 51° day arcs / golden angle, EXIF-driven film grain, scan lines fading as song ends.

**`linkedin/post-3-the-engineering.md`**
- Draft A (Constraint drives design): Builder's perspective — photographs had to stand as photographs, so QR codes were off the table. Engineering story.
- Draft B (User's experience inward): Starts from "you point your phone at a print" and works inward. Ends with the stochastic glitch: "the TV hasn't been fully repaired."
- **Bug fix**: The original draft had the Hamming distance threshold wrong (14 bits). Actual threshold is **18 bits**. Both new drafts are correct.

**`linkedin/post-4-the-case.md`**
- Draft A (Callback): Warm, retrospective, ties back to the viral bathroom moment. Echoes "add more of me" as a self-description.
- Draft B (Honest assessment): Leads with a provocation about taste. Uses EXIF-driven grain and stochastic glitch as proof of craft. More direct.
- Both drafts drop the resume-style background summary from the original.

**`linkedin/media-plan.md`**
- Documents the LinkedIn rule: cannot mix images and video in the same post
- Added difficulty ratings (Easy / Moderate / Hard) per post
- Clarified which media type each post should own (Post 3 owns the recognition GIF; Post 4 should be a still image)
- Updated format rules: all posts are now narrative, no bullet lists

## Reviewer notes

No code changes — LinkedIn content only. CI passes (lint, format, type-check, module README sync, tests, build, bundle size all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)