### PR TITLE
[codex] Add demo-only overlay-tolerant recognition

### DIFF
--- a/src/App.playbackFlow.test.tsx
+++ b/src/App.playbackFlow.test.tsx
@@ -75,6 +75,10 @@ const recognitionState = {
 const mockResetRecognition = vi.fn();
 const mockUsePhotoRecognition = vi.fn();
 const enabledFlags = new Set<string>();
+const env = import.meta.env as Record<string, string | undefined>;
+const originalPasscode = env.VITE_ACCESS_PASSCODE;
+const originalDemoPasscode = env.VITE_DEMO_PASSCODE;
+const originalMode = env.MODE;
 
 const createDebugTelemetry = (): RecognitionTelemetry => ({
   ...createEmptyTelemetry(),
@@ -194,6 +198,10 @@ describe('App playback flow', () => {
     recognitionState.detectedRectangle = null;
     recognitionState.rectangleConfidence = 0;
     enabledFlags.clear();
+    window.localStorage.clear();
+    env.VITE_ACCESS_PASSCODE = originalPasscode;
+    env.VITE_DEMO_PASSCODE = originalDemoPasscode;
+    env.MODE = originalMode;
 
     audioState.isPlaying = false;
     audioState.progress = 0;
@@ -225,6 +233,10 @@ describe('App playback flow', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    window.localStorage.clear();
+    env.VITE_ACCESS_PASSCODE = originalPasscode;
+    env.VITE_DEMO_PASSCODE = originalDemoPasscode;
+    env.MODE = originalMode;
   });
 
   const activateExperience = async (user: ReturnType<typeof userEvent.setup>) => {
@@ -265,6 +277,39 @@ describe('App playback flow', () => {
     expect(options?.sharpnessThreshold).toBe(85);
     expect(options?.recognitionDelay).toBe(180);
     expect(options?.continuousRecognition).toBe(true);
+    expect(options?.demoCropFallbackEnabled).toBe(false);
+  });
+
+  it('enables demo crop fallback only for active demo sessions', () => {
+    env.VITE_ACCESS_PASSCODE = '2468';
+    env.VITE_DEMO_PASSCODE = '9999';
+    env.MODE = 'production';
+    window.localStorage.setItem('photo-signal-user-type', 'demo');
+    window.localStorage.setItem('photo-signal-access-until', `${Date.now() + 60_000}`);
+
+    render(<App />);
+
+    const options = mockUsePhotoRecognition.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(options?.demoCropFallbackEnabled).toBe(true);
+    expect(options?.similarityThreshold).toBe(18);
+    expect(options?.matchMarginThreshold).toBe(5);
+  });
+
+  it('does not enable demo crop fallback for gallery sessions', () => {
+    env.VITE_ACCESS_PASSCODE = '2468';
+    env.VITE_DEMO_PASSCODE = '9999';
+    env.MODE = 'production';
+    window.localStorage.setItem('photo-signal-user-type', 'gallery');
+    window.localStorage.setItem('photo-signal-access-until', `${Date.now() + 60_000}`);
+
+    render(<App />);
+
+    const options = mockUsePhotoRecognition.mock.calls[0]?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(options?.demoCropFallbackEnabled).toBe(false);
   });
 
   it('auto-plays first recognized concert after activation', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -328,9 +328,10 @@ function AppContent() {
       sharpnessThreshold: 85,
       recognitionDelay: 180,
       continuousRecognition: true,
+      demoCropFallbackEnabled: isDemoMode,
       enabled: !showSecretSettings && !isConcertInfoVisible,
     }),
-    [isDebugOverlayVisible, isEnabled, isConcertInfoVisible, showSecretSettings]
+    [isDebugOverlayVisible, isEnabled, isConcertInfoVisible, isDemoMode, showSecretSettings]
   );
 
   const {

--- a/src/modules/debug-overlay/DebugOverlay.test.tsx
+++ b/src/modules/debug-overlay/DebugOverlay.test.tsx
@@ -212,6 +212,29 @@ describe('DebugOverlay', () => {
       expect(screen.getByText('Distance:')).toBeInTheDocument();
       expect(screen.getByText('Similarity:')).toBeInTheDocument();
     });
+
+    it('should display crop variant metadata when available', () => {
+      render(
+        <DebugOverlay
+          {...defaultProps}
+          debugInfo={{ ...mockDebugInfo, recognitionCropVariant: 'bottom-trim' }}
+        />
+      );
+
+      expect(screen.getByText('Crop:')).toBeInTheDocument();
+      expect(screen.getByText('bottom-trim')).toBeInTheDocument();
+    });
+
+    it('should hide crop variant metadata when unavailable', () => {
+      render(
+        <DebugOverlay
+          {...defaultProps}
+          debugInfo={{ ...mockDebugInfo, recognitionCropVariant: null }}
+        />
+      );
+
+      expect(screen.queryByText('Crop:')).not.toBeInTheDocument();
+    });
   });
 
   describe('Guidance', () => {

--- a/src/modules/debug-overlay/DebugOverlay.tsx
+++ b/src/modules/debug-overlay/DebugOverlay.tsx
@@ -28,6 +28,7 @@ export function DebugOverlay({
   const bestMatch = debugInfo?.bestMatch ?? null;
   const secondBestMatch = debugInfo?.secondBestMatch ?? null;
   const bestMatchMargin = debugInfo?.bestMatchMargin ?? null;
+  const recognitionCropVariant = debugInfo?.recognitionCropVariant ?? null;
   // Select highest-priority recommendation (high > medium > low)
   const priorityOrder = { high: 0, medium: 1, low: 2 };
   const sorted = [...recommendations].sort(
@@ -182,6 +183,14 @@ export function DebugOverlay({
                     <span className={styles.statValue}>
                       {bestMatchMargin !== null ? bestMatchMargin.toFixed(1) : '—'}
                     </span>
+                  </div>
+                </div>
+              ) : null}
+              {recognitionCropVariant ? (
+                <div className={styles.matchStats}>
+                  <div className={styles.stat}>
+                    <span className={styles.statLabel}>Crop:</span>
+                    <span className={styles.statValue}>{recognitionCropVariant}</span>
                   </div>
                 </div>
               ) : null}

--- a/src/modules/photo-recognition/README.md
+++ b/src/modules/photo-recognition/README.md
@@ -41,6 +41,7 @@ Derive recommended threshold adjustments from aggregated telemetry (used in debu
 - Comparing hashes against `data.recognition.v2.json` at multiple exposure variants
 - Requiring sustained match stability before emitting `recognizedConcert`
 - Collecting telemetry (`RecognitionDebugInfo`) when debug mode is enabled
+- Optionally evaluating demo-only crop variants (`demoCropFallbackEnabled`) so remote users can scan blog photos with browser chrome or download overlays in frame
 
 ## Does NOT Own
 

--- a/src/modules/photo-recognition/__tests__/pipelineHelpers.test.ts
+++ b/src/modules/photo-recognition/__tests__/pipelineHelpers.test.ts
@@ -292,6 +292,13 @@ describe('buildDebugInfo', () => {
     expect(buildDebugInfo({ ...baseArgs(), frameQuality: null }).frameQuality).toBeNull();
   });
 
+  it('includes recognition crop variant metadata when supplied', () => {
+    expect(
+      buildDebugInfo({ ...baseArgs(), recognitionCropVariant: 'bottom-trim' })
+        .recognitionCropVariant
+    ).toBe('bottom-trim');
+  });
+
   it('passes a FrameQualityInfo object through by reference', () => {
     const frameQuality: FrameQualityInfo = {
       sharpness: 150,

--- a/src/modules/photo-recognition/recognition.worker.test.ts
+++ b/src/modules/photo-recognition/recognition.worker.test.ts
@@ -15,6 +15,7 @@ const mockComputeAllQualityMetrics = vi.hoisted(() =>
     lightingType: 'ok' as const,
   }))
 );
+const drawImageCalls = vi.hoisted(() => [] as unknown[][]);
 
 vi.mock('./algorithms/phash', () => ({
   computePHash: mockComputePHash,
@@ -52,7 +53,9 @@ class MockOffscreenCanvas {
 
   getContext() {
     return {
-      drawImage: vi.fn(),
+      drawImage: vi.fn((...args: unknown[]) => {
+        drawImageCalls.push(args);
+      }),
       clearRect: vi.fn(),
       putImageData: vi.fn(),
       getImageData: vi.fn((x: number, y: number, width: number, height: number) => {
@@ -97,6 +100,7 @@ describe('recognition.worker', () => {
       hasPoorLighting: false,
       lightingType: 'ok',
     });
+    drawImageCalls.length = 0;
 
     vi.stubGlobal('OffscreenCanvas', MockOffscreenCanvas);
     vi.stubGlobal('self', {
@@ -179,8 +183,252 @@ describe('recognition.worker', () => {
       expect.objectContaining({
         type: 'result',
         frameId: 9,
+        cropVariant: 'full',
         bestMatch: { concertId: 1, distance: 4 },
         quality: null,
+      })
+    );
+  });
+
+  it('uses a clear bottom-trim fallback match when demo crop fallback is enabled', async () => {
+    const selfRef = await loadWorkerModule();
+    const bitmap = makeBitmap();
+
+    mockComputePHash
+      .mockReturnValueOnce('full-noisy')
+      .mockReturnValueOnce('bottom-clear')
+      .mockReturnValueOnce('center-noisy');
+    mockHammingDistance.mockImplementation((frameHash: string, candidateHash: string) => {
+      if (frameHash === 'bottom-clear' && candidateHash === 'aaaaaaaaaaaaaaaa') {
+        return 5;
+      }
+      if (frameHash === 'bottom-clear' && candidateHash === 'bbbbbbbbbbbbbbbb') {
+        return 24;
+      }
+      return candidateHash === 'aaaaaaaaaaaaaaaa' ? 19 : 23;
+    });
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'init',
+        hashEntries: [
+          { hash: 'aaaaaaaaaaaaaaaa', concertId: 1 },
+          { hash: 'bbbbbbbbbbbbbbbb', concertId: 2 },
+        ],
+        config: { ...baseConfig, demoCropFallbackEnabled: true },
+      },
+    } as MessageEvent);
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'frame',
+        bitmap,
+        frameId: 15,
+      },
+    } as MessageEvent);
+
+    expect(mockComputePHash).toHaveBeenCalledTimes(2);
+    expect(selfRef.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        frameId: 15,
+        hash: 'bottom-clear',
+        cropVariant: 'bottom-trim',
+        bestMatch: { concertId: 1, distance: 5 },
+      })
+    );
+  });
+
+  it('prefers the full crop when it already produces a valid match', async () => {
+    const selfRef = await loadWorkerModule();
+    const bitmap = makeBitmap();
+
+    mockComputePHash
+      .mockReturnValueOnce('full-clear')
+      .mockReturnValueOnce('bottom-clear')
+      .mockReturnValueOnce('center-clear');
+    mockHammingDistance.mockImplementation((frameHash: string, candidateHash: string) => {
+      if (candidateHash !== 'aaaaaaaaaaaaaaaa') {
+        return 30;
+      }
+      return frameHash === 'full-clear' ? 8 : 4;
+    });
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'init',
+        hashEntries: [
+          { hash: 'aaaaaaaaaaaaaaaa', concertId: 1 },
+          { hash: 'bbbbbbbbbbbbbbbb', concertId: 2 },
+        ],
+        config: { ...baseConfig, demoCropFallbackEnabled: true },
+      },
+    } as MessageEvent);
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'frame',
+        bitmap,
+        frameId: 16,
+      },
+    } as MessageEvent);
+
+    expect(mockComputePHash).toHaveBeenCalledTimes(1);
+    expect(selfRef.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        frameId: 16,
+        hash: 'full-clear',
+        cropVariant: 'full',
+        bestMatch: { concertId: 1, distance: 8 },
+      })
+    );
+  });
+
+  it('uses center-trim when top and bottom chrome obscure the full crop', async () => {
+    const selfRef = await loadWorkerModule();
+    const bitmap = makeBitmap();
+
+    mockComputePHash
+      .mockReturnValueOnce('full-noisy')
+      .mockReturnValueOnce('bottom-still-noisy')
+      .mockReturnValueOnce('center-clear');
+    mockHammingDistance.mockImplementation((frameHash: string, candidateHash: string) => {
+      if (candidateHash === 'bbbbbbbbbbbbbbbb') {
+        return 30;
+      }
+
+      if (frameHash === 'center-clear') {
+        return 6;
+      }
+
+      return frameHash === 'bottom-still-noisy' ? 16 : 18;
+    });
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'init',
+        hashEntries: [
+          { hash: 'aaaaaaaaaaaaaaaa', concertId: 1 },
+          { hash: 'bbbbbbbbbbbbbbbb', concertId: 2 },
+        ],
+        config: { ...baseConfig, demoCropFallbackEnabled: true },
+      },
+    } as MessageEvent);
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'frame',
+        bitmap,
+        frameId: 17,
+      },
+    } as MessageEvent);
+
+    expect(selfRef.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        frameId: 17,
+        hash: 'center-clear',
+        cropVariant: 'center-trim',
+        bestMatch: { concertId: 1, distance: 6 },
+      })
+    );
+  });
+
+  it('does not enable crop fallback when demo crop fallback is disabled', async () => {
+    const selfRef = await loadWorkerModule();
+    const bitmap = makeBitmap();
+
+    mockComputePHash.mockReturnValueOnce('full-only');
+    mockHammingDistance.mockImplementation((_: string, candidateHash: string) =>
+      candidateHash === 'aaaaaaaaaaaaaaaa' ? 18 : 30
+    );
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'init',
+        hashEntries: [
+          { hash: 'aaaaaaaaaaaaaaaa', concertId: 1 },
+          { hash: 'bbbbbbbbbbbbbbbb', concertId: 2 },
+        ],
+        config: { ...baseConfig, demoCropFallbackEnabled: false },
+      },
+    } as MessageEvent);
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'frame',
+        bitmap,
+        frameId: 18,
+      },
+    } as MessageEvent);
+
+    expect(mockComputePHash).toHaveBeenCalledTimes(1);
+    expect(selfRef.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        frameId: 18,
+        hash: 'full-only',
+        cropVariant: 'full',
+        bestMatch: { concertId: 1, distance: 18 },
+      })
+    );
+  });
+
+  it('runs quality for ambiguous fallback matches instead of treating them as confident', async () => {
+    const selfRef = await loadWorkerModule();
+    const bitmap = makeBitmap();
+
+    mockComputePHash
+      .mockReturnValueOnce('full-noisy')
+      .mockReturnValueOnce('bottom-ambiguous')
+      .mockReturnValueOnce('center-noisy');
+    mockHammingDistance.mockImplementation((frameHash: string, candidateHash: string) => {
+      if (frameHash === 'bottom-ambiguous') {
+        return candidateHash === 'aaaaaaaaaaaaaaaa' ? 5 : 7;
+      }
+      return candidateHash === 'aaaaaaaaaaaaaaaa' ? 20 : 22;
+    });
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'init',
+        hashEntries: [
+          { hash: 'aaaaaaaaaaaaaaaa', concertId: 1 },
+          { hash: 'bbbbbbbbbbbbbbbb', concertId: 2 },
+        ],
+        config: { ...baseConfig, demoCropFallbackEnabled: true },
+      },
+    } as MessageEvent);
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'frame',
+        bitmap,
+        frameId: 19,
+      },
+    } as MessageEvent);
+
+    expect(mockComputeAllQualityMetrics).toHaveBeenCalledTimes(1);
+    expect(drawImageCalls[drawImageCalls.length - 1]).toEqual([
+      bitmap,
+      0,
+      0,
+      64,
+      50,
+      0,
+      0,
+      128,
+      128,
+    ]);
+    expect(selfRef.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        frameId: 19,
+        cropVariant: 'bottom-trim',
+        bestMatch: { concertId: 1, distance: 5 },
+        secondBestMatch: { concertId: 2, distance: 7 },
+        quality: expect.objectContaining({ isSharp: true }),
       })
     );
   });
@@ -271,6 +519,65 @@ describe('recognition.worker', () => {
         type: 'result',
         frameId: 12,
         bestMatch: { concertId: 1, distance: 6 },
+      })
+    );
+  });
+
+  it('measures quality on the rectified full crop when perspective metadata is active', async () => {
+    const selfRef = await loadWorkerModule();
+    const bitmap = makeBitmap();
+
+    mockHammingDistance.mockImplementation((_: string, candidateHash: string) =>
+      candidateHash === 'aaaaaaaaaaaaaaaa' ? 13 : 25
+    );
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'init',
+        hashEntries: [
+          { hash: 'aaaaaaaaaaaaaaaa', concertId: 1 },
+          { hash: 'bbbbbbbbbbbbbbbb', concertId: 2 },
+        ],
+        config: baseConfig,
+      },
+    } as MessageEvent);
+
+    selfRef.onmessage?.({
+      data: {
+        type: 'frame',
+        bitmap,
+        frameId: 20,
+        perspective: {
+          corners: [
+            { x: 4, y: 4 },
+            { x: 60, y: 8 },
+            { x: 58, y: 58 },
+            { x: 6, y: 56 },
+          ],
+          targetAspect: '3:2',
+        },
+      },
+    } as MessageEvent);
+
+    expect(mockComputeAllQualityMetrics).toHaveBeenCalledTimes(1);
+    expect(drawImageCalls[drawImageCalls.length - 1]?.[0]).not.toBe(bitmap);
+    expect(drawImageCalls[drawImageCalls.length - 1]).toEqual([
+      expect.any(MockOffscreenCanvas),
+      0,
+      0,
+      96,
+      64,
+      0,
+      0,
+      128,
+      128,
+    ]);
+    expect(selfRef.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'result',
+        frameId: 20,
+        cropVariant: 'full',
+        quality: expect.objectContaining({ isSharp: true }),
       })
     );
   });

--- a/src/modules/photo-recognition/recognition.worker.ts
+++ b/src/modules/photo-recognition/recognition.worker.ts
@@ -14,6 +14,11 @@
 import { computePHash } from './algorithms/phash';
 import { hammingDistance } from './algorithms/hamming';
 import { computeAllQualityMetrics } from './algorithms/utils';
+import {
+  getRecognitionCropVariants,
+  type RecognitionCropVariant,
+  type RecognitionCropVariantId,
+} from './recognitionCropVariants';
 import type {
   MainToWorkerMessage,
   WorkerPerspectiveFrameData,
@@ -346,44 +351,6 @@ function warpToAspectImageData(
   return target;
 }
 
-function drawImageDataContained(
-  destinationCtx: OffscreenCanvasRenderingContext2D,
-  destinationCanvas: OffscreenCanvas,
-  imageData: ImageData
-): void {
-  const tempCtx = ensureImageDataCanvas(imageData.width, imageData.height);
-  tempCtx.putImageData(imageData, 0, 0);
-
-  const sourceAspect = imageData.width / imageData.height;
-  const destinationAspect = destinationCanvas.width / destinationCanvas.height;
-
-  let drawWidth = destinationCanvas.width;
-  let drawHeight = destinationCanvas.height;
-  let drawX = 0;
-  let drawY = 0;
-
-  if (sourceAspect > destinationAspect) {
-    drawHeight = destinationCanvas.width / sourceAspect;
-    drawY = (destinationCanvas.height - drawHeight) / 2;
-  } else {
-    drawWidth = destinationCanvas.height * sourceAspect;
-    drawX = (destinationCanvas.width - drawWidth) / 2;
-  }
-
-  destinationCtx.clearRect(0, 0, destinationCanvas.width, destinationCanvas.height);
-  destinationCtx.drawImage(
-    imageDataCanvas!,
-    0,
-    0,
-    imageData.width,
-    imageData.height,
-    drawX,
-    drawY,
-    drawWidth,
-    drawHeight
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Matching — worker-local variant of findBestMatches using concertId
 // ---------------------------------------------------------------------------
@@ -391,6 +358,14 @@ function drawImageDataContained(
 interface WorkerMatchCandidate {
   concertId: number;
   distance: number;
+}
+
+interface WorkerVariantMatch {
+  cropVariant: RecognitionCropVariantId;
+  hash: string;
+  bestMatch: WorkerMatchCandidate | null;
+  secondBestMatch: WorkerMatchCandidate | null;
+  isActiveMatch: boolean;
 }
 
 function findBestMatches(
@@ -421,6 +396,166 @@ function findBestMatches(
 // ---------------------------------------------------------------------------
 // Frame processing
 // ---------------------------------------------------------------------------
+
+function drawBitmapVariantForHash(bitmap: ImageBitmap, variant: RecognitionCropVariant): ImageData {
+  const hCtx = ensureHashCanvas();
+  hashCanvas!.width = PHASH_SIZE;
+  hashCanvas!.height = PHASH_SIZE;
+  hCtx.clearRect(0, 0, PHASH_SIZE, PHASH_SIZE);
+  hCtx.drawImage(
+    bitmap,
+    variant.x,
+    variant.y,
+    variant.width,
+    variant.height,
+    0,
+    0,
+    PHASH_SIZE,
+    PHASH_SIZE
+  );
+  return hCtx.getImageData(0, 0, PHASH_SIZE, PHASH_SIZE);
+}
+
+function drawImageDataVariantForHash(
+  imageData: ImageData,
+  variant: RecognitionCropVariant
+): ImageData {
+  const sourceCtx = ensureImageDataCanvas(imageData.width, imageData.height);
+  sourceCtx.putImageData(imageData, 0, 0);
+
+  const hCtx = ensureHashCanvas();
+  hashCanvas!.width = PHASH_SIZE;
+  hashCanvas!.height = PHASH_SIZE;
+  hCtx.clearRect(0, 0, PHASH_SIZE, PHASH_SIZE);
+
+  const sourceAspect = variant.width / variant.height;
+  const destinationAspect = PHASH_SIZE / PHASH_SIZE;
+  let drawWidth = PHASH_SIZE;
+  let drawHeight = PHASH_SIZE;
+  let drawX = 0;
+  let drawY = 0;
+
+  if (sourceAspect > destinationAspect) {
+    drawHeight = PHASH_SIZE / sourceAspect;
+    drawY = (PHASH_SIZE - drawHeight) / 2;
+  } else {
+    drawWidth = PHASH_SIZE * sourceAspect;
+    drawX = (PHASH_SIZE - drawWidth) / 2;
+  }
+
+  hCtx.drawImage(
+    imageDataCanvas!,
+    variant.x,
+    variant.y,
+    variant.width,
+    variant.height,
+    drawX,
+    drawY,
+    drawWidth,
+    drawHeight
+  );
+  return hCtx.getImageData(0, 0, PHASH_SIZE, PHASH_SIZE);
+}
+
+function drawBitmapVariantForQuality(
+  bitmap: ImageBitmap,
+  variant: RecognitionCropVariant
+): ImageData {
+  const qCtx = ensureQualityCanvas();
+  qualityCanvas!.width = QUALITY_SIZE;
+  qualityCanvas!.height = QUALITY_SIZE;
+  qCtx.clearRect(0, 0, QUALITY_SIZE, QUALITY_SIZE);
+  qCtx.drawImage(
+    bitmap,
+    variant.x,
+    variant.y,
+    variant.width,
+    variant.height,
+    0,
+    0,
+    QUALITY_SIZE,
+    QUALITY_SIZE
+  );
+  return qCtx.getImageData(0, 0, QUALITY_SIZE, QUALITY_SIZE);
+}
+
+function drawImageDataVariantForQuality(
+  imageData: ImageData,
+  variant: RecognitionCropVariant
+): ImageData {
+  const sourceCtx = ensureImageDataCanvas(imageData.width, imageData.height);
+  sourceCtx.putImageData(imageData, 0, 0);
+
+  const qCtx = ensureQualityCanvas();
+  qualityCanvas!.width = QUALITY_SIZE;
+  qualityCanvas!.height = QUALITY_SIZE;
+  qCtx.clearRect(0, 0, QUALITY_SIZE, QUALITY_SIZE);
+  qCtx.drawImage(
+    imageDataCanvas!,
+    variant.x,
+    variant.y,
+    variant.width,
+    variant.height,
+    0,
+    0,
+    QUALITY_SIZE,
+    QUALITY_SIZE
+  );
+  return qCtx.getImageData(0, 0, QUALITY_SIZE, QUALITY_SIZE);
+}
+
+function isActiveMatchCandidate(
+  bestMatch: WorkerMatchCandidate | null,
+  secondBestMatch: WorkerMatchCandidate | null,
+  cfg: WorkerRecognitionConfig
+): boolean {
+  const isWithinThreshold = !!bestMatch && bestMatch.distance <= cfg.similarityThreshold;
+  if (!isWithinThreshold) {
+    return false;
+  }
+
+  const bestMargin =
+    bestMatch && secondBestMatch ? secondBestMatch.distance - bestMatch.distance : null;
+  const marginBoost =
+    bestMatch && bestMatch.distance >= Math.max(cfg.similarityThreshold - 1, 0) ? 1 : 0;
+  const effectiveMarginRequired = cfg.matchMarginThreshold + marginBoost;
+  const hasSufficientMargin = bestMargin === null || bestMargin >= effectiveMarginRequired;
+  const isExactCrossConcertTie =
+    secondBestMatch !== null && bestMatch!.distance === secondBestMatch.distance;
+
+  return hasSufficientMargin && !isExactCrossConcertTie;
+}
+
+function compareVariantMatches(a: WorkerVariantMatch, b: WorkerVariantMatch): WorkerVariantMatch {
+  if (a.cropVariant === 'full' && a.isActiveMatch) {
+    return a;
+  }
+
+  if (b.cropVariant === 'full' && b.isActiveMatch) {
+    return b;
+  }
+
+  if (a.isActiveMatch !== b.isActiveMatch) {
+    return a.isActiveMatch ? a : b;
+  }
+
+  const aDistance = a.bestMatch?.distance ?? Number.POSITIVE_INFINITY;
+  const bDistance = b.bestMatch?.distance ?? Number.POSITIVE_INFINITY;
+  if (aDistance !== bDistance) {
+    return aDistance < bDistance ? a : b;
+  }
+
+  const aMargin =
+    a.bestMatch && a.secondBestMatch
+      ? a.secondBestMatch.distance - a.bestMatch.distance
+      : Number.POSITIVE_INFINITY;
+  const bMargin =
+    b.bestMatch && b.secondBestMatch
+      ? b.secondBestMatch.distance - b.bestMatch.distance
+      : Number.POSITIVE_INFINITY;
+
+  return aMargin >= bMargin ? a : b;
+}
 
 function processFrame(
   bitmap: ImageBitmap,
@@ -472,55 +607,70 @@ function processFrame(
     rectifiedImageData = warpToAspectImageData(sourceImageData, scaledPerspective);
   }
 
-  // 1. Draw bitmap at 32×32 for pHash — resizeImageData will short-circuit
-  const hCtx = ensureHashCanvas();
-  hashCanvas!.width = PHASH_SIZE;
-  hashCanvas!.height = PHASH_SIZE;
-  if (rectifiedImageData) {
-    drawImageDataContained(hCtx, hashCanvas!, rectifiedImageData);
-  } else {
-    hCtx.drawImage(bitmap, 0, 0, PHASH_SIZE, PHASH_SIZE);
+  const sourceWidth = rectifiedImageData?.width ?? bitmap.width;
+  const sourceHeight = rectifiedImageData?.height ?? bitmap.height;
+  const variants = getRecognitionCropVariants(
+    sourceWidth,
+    sourceHeight,
+    config?.demoCropFallbackEnabled === true
+  );
+
+  let selectedVariant: WorkerVariantMatch | null = null;
+
+  for (const variant of variants) {
+    const hashImageData = rectifiedImageData
+      ? drawImageDataVariantForHash(rectifiedImageData, variant)
+      : drawBitmapVariantForHash(bitmap, variant);
+    const hash = computePHash(hashImageData);
+    const { bestMatch, secondBestMatch } = findBestMatches(hash, hashEntries);
+    const variantMatch: WorkerVariantMatch = {
+      cropVariant: variant.id,
+      hash,
+      bestMatch,
+      secondBestMatch,
+      isActiveMatch: isActiveMatchCandidate(bestMatch, secondBestMatch, config!),
+    };
+
+    selectedVariant = selectedVariant
+      ? compareVariantMatches(selectedVariant, variantMatch)
+      : variantMatch;
+
+    if (variantMatch.isActiveMatch) {
+      break;
+    }
   }
-  const hashImageData = hCtx.getImageData(0, 0, PHASH_SIZE, PHASH_SIZE);
 
-  // 2. Compute pHash (resize is a no-op since input is already 32×32)
-  const hash = computePHash(hashImageData);
+  if (!selectedVariant) {
+    selectedVariant = {
+      cropVariant: 'full',
+      hash: '',
+      bestMatch: null,
+      secondBestMatch: null,
+      isActiveMatch: false,
+    };
+  }
 
-  // 3. Find best matches
-  const { bestMatch, secondBestMatch } = findBestMatches(hash, hashEntries);
+  const selectedCrop =
+    variants.find((variant) => variant.id === selectedVariant.cropVariant) ?? variants[0];
+  const { hash, bestMatch, secondBestMatch } = selectedVariant;
 
-  // 4. Determine if quality checks are needed, mirroring the main-thread condition:
+  // Determine if quality checks are needed, mirroring the main-thread condition:
   //    shouldRunQualityCheck = !bestMatch || !activeMatch || distance > gatingThreshold
   //
   // We replicate the active-match decision here so quality always runs for
   // ambiguous candidates (within threshold but failing margin / tie checks) —
   // same as the inline pipeline.
   const cfg = config!;
-  const isWithinThreshold = !!bestMatch && bestMatch.distance <= cfg.similarityThreshold;
-  let activeMatchExists = false;
-  if (isWithinThreshold) {
-    const bestMargin =
-      bestMatch && secondBestMatch ? secondBestMatch.distance - bestMatch.distance : null;
-    const marginBoost =
-      bestMatch && bestMatch.distance >= Math.max(cfg.similarityThreshold - 1, 0) ? 1 : 0;
-    const effectiveMarginRequired = cfg.matchMarginThreshold + marginBoost;
-    const hasSufficientMargin = bestMargin === null || bestMargin >= effectiveMarginRequired;
-    const isExactCrossConcertTie =
-      secondBestMatch !== null && bestMatch!.distance === secondBestMatch.distance;
-    activeMatchExists = hasSufficientMargin && !isExactCrossConcertTie;
-  }
+  const activeMatchExists = selectedVariant.isActiveMatch;
   const shouldRunQuality =
     !bestMatch || !activeMatchExists || bestMatch.distance > cfg.qualityGatingDistanceThreshold;
 
   let quality: WorkerFrameResult['quality'] = null;
 
   if (shouldRunQuality) {
-    // Draw bitmap at 128×128 for quality metrics
-    const qCtx = ensureQualityCanvas();
-    qualityCanvas!.width = QUALITY_SIZE;
-    qualityCanvas!.height = QUALITY_SIZE;
-    qCtx.drawImage(bitmap, 0, 0, QUALITY_SIZE, QUALITY_SIZE);
-    const qualityImageData = qCtx.getImageData(0, 0, QUALITY_SIZE, QUALITY_SIZE);
+    const qualityImageData = rectifiedImageData
+      ? drawImageDataVariantForQuality(rectifiedImageData, selectedCrop)
+      : drawBitmapVariantForQuality(bitmap, selectedCrop);
 
     const metrics = computeAllQualityMetrics(
       qualityImageData,
@@ -544,6 +694,7 @@ function processFrame(
     type: 'result',
     frameId,
     hash,
+    cropVariant: selectedVariant.cropVariant,
     bestMatch: toResult(bestMatch),
     secondBestMatch: toResult(secondBestMatch),
     quality,

--- a/src/modules/photo-recognition/recognitionCropVariants.test.ts
+++ b/src/modules/photo-recognition/recognitionCropVariants.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getRecognitionCropVariants } from './recognitionCropVariants';
+
+describe('getRecognitionCropVariants', () => {
+  it('returns only the full crop when demo fallback is disabled', () => {
+    expect(getRecognitionCropVariants(640, 480, false)).toEqual([
+      { id: 'full', x: 0, y: 0, width: 640, height: 480 },
+    ]);
+  });
+
+  it('adds bottom and center trims when demo fallback is enabled', () => {
+    expect(getRecognitionCropVariants(100, 100, true)).toEqual([
+      { id: 'full', x: 0, y: 0, width: 100, height: 100 },
+      { id: 'bottom-trim', x: 0, y: 0, width: 100, height: 78 },
+      { id: 'center-trim', x: 0, y: 8, width: 100, height: 74 },
+    ]);
+  });
+
+  it('keeps all enabled crop variants inside source bounds', () => {
+    const variants = getRecognitionCropVariants(320, 240, true);
+
+    for (const variant of variants) {
+      expect(variant.x).toBeGreaterThanOrEqual(0);
+      expect(variant.y).toBeGreaterThanOrEqual(0);
+      expect(variant.x + variant.width).toBeLessThanOrEqual(320);
+      expect(variant.y + variant.height).toBeLessThanOrEqual(240);
+    }
+  });
+
+  it('drops trims that would be too small to hash reliably', () => {
+    expect(getRecognitionCropVariants(100, 18, true)).toEqual([
+      { id: 'full', x: 0, y: 0, width: 100, height: 18 },
+    ]);
+  });
+});

--- a/src/modules/photo-recognition/recognitionCropVariants.ts
+++ b/src/modules/photo-recognition/recognitionCropVariants.ts
@@ -1,0 +1,76 @@
+export type RecognitionCropVariantId = 'full' | 'bottom-trim' | 'center-trim';
+
+export interface RecognitionCropVariant {
+  id: RecognitionCropVariantId;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const BOTTOM_TRIM_FRACTION = 0.22;
+const CENTER_TOP_TRIM_FRACTION = 0.08;
+const CENTER_BOTTOM_TRIM_FRACTION = 0.18;
+const MIN_VARIANT_SIZE = 16;
+
+const clampRegion = (
+  id: RecognitionCropVariantId,
+  sourceWidth: number,
+  sourceHeight: number,
+  topTrimFraction: number,
+  bottomTrimFraction: number
+): RecognitionCropVariant | null => {
+  const y = Math.round(sourceHeight * topTrimFraction);
+  const bottomTrim = Math.round(sourceHeight * bottomTrimFraction);
+  const height = sourceHeight - y - bottomTrim;
+
+  if (sourceWidth < MIN_VARIANT_SIZE || height < MIN_VARIANT_SIZE) {
+    return null;
+  }
+
+  return {
+    id,
+    x: 0,
+    y,
+    width: sourceWidth,
+    height,
+  };
+};
+
+export function getRecognitionCropVariants(
+  sourceWidth: number,
+  sourceHeight: number,
+  demoCropFallbackEnabled: boolean
+): RecognitionCropVariant[] {
+  const full: RecognitionCropVariant = {
+    id: 'full',
+    x: 0,
+    y: 0,
+    width: sourceWidth,
+    height: sourceHeight,
+  };
+
+  if (!demoCropFallbackEnabled) {
+    return [full];
+  }
+
+  const variants = [full];
+  const bottomTrim = clampRegion('bottom-trim', sourceWidth, sourceHeight, 0, BOTTOM_TRIM_FRACTION);
+  const centerTrim = clampRegion(
+    'center-trim',
+    sourceWidth,
+    sourceHeight,
+    CENTER_TOP_TRIM_FRACTION,
+    CENTER_BOTTOM_TRIM_FRACTION
+  );
+
+  if (bottomTrim) {
+    variants.push(bottomTrim);
+  }
+
+  if (centerTrim) {
+    variants.push(centerTrim);
+  }
+
+  return variants;
+}

--- a/src/modules/photo-recognition/types.ts
+++ b/src/modules/photo-recognition/types.ts
@@ -1,5 +1,6 @@
 import type { Concert, AspectRatio as AspectRatioType } from '../../types';
 import type { DetectedRectangle } from '../photo-rectangle-detection';
+import type { RecognitionCropVariantId } from './recognitionCropVariants';
 
 export type AspectRatio = AspectRatioType;
 export type HashAlgorithm = 'phash';
@@ -187,6 +188,7 @@ export interface RecognitionDebugInfo {
   similarityThreshold: number;
   recognitionDelay: number;
   frameQuality: FrameQualityInfo | null;
+  recognitionCropVariant?: RecognitionCropVariantId | null;
   telemetry: RecognitionTelemetry;
   hashAlgorithm: HashAlgorithm;
 }
@@ -244,4 +246,6 @@ export interface PhotoRecognitionOptions {
   rectangleConfidenceThreshold?: number;
   /** Aspect ratio of the display viewport, used to compute crop regions. Default: 1 */
   displayAspectRatio?: number;
+  /** Demo-only overlay fallback that evaluates vertically trimmed crop variants. Default: false */
+  demoCropFallbackEnabled?: boolean;
 }

--- a/src/modules/photo-recognition/usePhotoRecognition.test.ts
+++ b/src/modules/photo-recognition/usePhotoRecognition.test.ts
@@ -12,6 +12,7 @@ import {
 
 const mockIsEnabled = vi.fn<(flag: string) => boolean>(() => false);
 let activeFrameHash = 'a5b3c7d9e1f20486';
+let activeFrameHashQueue: string[] | null = null;
 const mockWorkerProcessFrame = vi.fn();
 const workerHookState: {
   isReady: boolean;
@@ -41,7 +42,7 @@ vi.mock('../../services/data-service', () => ({
 }));
 
 vi.mock('./algorithms/phash', () => ({
-  computePHash: vi.fn(() => activeFrameHash),
+  computePHash: vi.fn(() => activeFrameHashQueue?.shift() ?? activeFrameHash),
 }));
 
 vi.mock('./algorithms/hamming', () => ({
@@ -122,7 +123,11 @@ describe('usePhotoRecognition', () => {
         usePhotoRecognition(mockStream, { enabled: true, checkInterval: 50 })
       );
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(200);
+        await vi.advanceTimersByTimeAsync(100);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
       });
       // The pre-hash blur gate should have triggered: no match, not recognizing
       expect(result.current.recognizedConcert).toBeNull();
@@ -166,6 +171,7 @@ describe('usePhotoRecognition', () => {
     // Tests that want to exercise the gate override this spy locally.
     vi.spyOn(qualityUtils, 'computeLaplacianVariance').mockReturnValue(200);
     activeFrameHash = 'a5b3c7d9e1f20486';
+    activeFrameHashQueue = null;
     workerHookState.isReady = false;
     workerHookState.isSupported = false;
     workerHookState.onResult = null;
@@ -531,14 +537,89 @@ describe('usePhotoRecognition', () => {
       });
 
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(300);
+        await vi.advanceTimersByTimeAsync(1_000);
       });
 
+      expect(mockContext.drawImage).toHaveBeenCalled();
+
+      console.log(result.current.debugInfo);
       expect(result.current.recognizedConcert?.id).toBe(1);
       expect((result.current.debugInfo?.telemetry.index_mode_used ?? 0) > 0).toBe(true);
       expect((result.current.debugInfo?.telemetry.candidate_count_per_frame?.last ?? 0) > 0).toBe(
         true
       );
+    } finally {
+      createElementSpy.mockRestore();
+    }
+  });
+
+  it('uses demo crop fallback variants on the inline path when the full crop misses', async () => {
+    const originalCreateElement = document.createElement.bind(document);
+
+    const mockContext = {
+      drawImage: vi.fn(),
+      getImageData: vi.fn(() => new ImageData(64, 64)),
+    } as unknown as CanvasRenderingContext2D;
+
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation(((
+      tagName: string,
+      options?: ElementCreationOptions
+    ) => {
+      if (tagName === 'video') {
+        const video = originalCreateElement('video', options) as HTMLVideoElement;
+        Object.defineProperty(video, 'videoWidth', { value: 640, configurable: true });
+        Object.defineProperty(video, 'videoHeight', { value: 480, configurable: true });
+        Object.defineProperty(video, 'readyState', {
+          value: HTMLMediaElement.HAVE_CURRENT_DATA,
+          configurable: true,
+        });
+        return video;
+      }
+
+      if (tagName === 'canvas') {
+        const canvas = originalCreateElement('canvas', options) as HTMLCanvasElement;
+        Object.defineProperty(canvas, 'getContext', {
+          value: vi.fn(() => mockContext),
+          configurable: true,
+        });
+        return canvas;
+      }
+
+      return originalCreateElement(tagName, options);
+    }) as typeof document.createElement);
+
+    try {
+      activeFrameHashQueue = ['ffffffffffffffff', 'a5b3c7d9e1f20486'];
+
+      const { result } = renderHook(() =>
+        usePhotoRecognition(mockStream, {
+          enabled: true,
+          checkInterval: 50,
+          demoCropFallbackEnabled: true,
+          enableDebugInfo: true,
+        })
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000);
+      });
+
+      expect(mockContext.drawImage).toHaveBeenCalled();
+      expect(result.current.debugInfo).toMatchObject({
+        recognitionCropVariant: 'bottom-trim',
+      });
+      expect(result.current.recognizedConcert?.id).toBe(1);
+      expect(
+        vi
+          .mocked(mockContext.drawImage)
+          .mock.calls.some(
+            (call) => call[1] === 128 && call[2] === 112 && call[3] === 384 && call[4] === 200
+          )
+      ).toBe(true);
     } finally {
       createElementSpy.mockRestore();
     }

--- a/src/modules/photo-recognition/usePhotoRecognition.ts
+++ b/src/modules/photo-recognition/usePhotoRecognition.ts
@@ -29,6 +29,10 @@ import type {
   WorkerPerspectiveFrameData,
   WorkerRecognitionConfig,
 } from './worker-protocol';
+import {
+  getRecognitionCropVariants,
+  type RecognitionCropVariantId,
+} from './recognitionCropVariants';
 import type {
   AspectRatio,
   FailureCategory,
@@ -161,6 +165,15 @@ const DEFAULT_MATCH_MARGIN_THRESHOLD = 4;
 /** Compact type used throughout the matching pipeline. */
 export type MatchCandidate = { concert: Concert; distance: number };
 type HashEntry = { hash: string; concert: Concert };
+type InlineVariantMatch = {
+  cropVariant: RecognitionCropVariantId;
+  hash: string;
+  bestMatch: MatchCandidate | null;
+  secondBestMatch: MatchCandidate | null;
+  isActiveMatch: boolean;
+  region: ViewportRegion;
+  imageData: ImageData;
+};
 
 const HASH_BUCKET_PREFIX_LENGTH = 0;
 
@@ -288,6 +301,66 @@ export function getAdaptiveRecognitionDelay(distance: number, recognitionDelay: 
   return Math.round(recognitionDelay * 1.3);
 }
 
+function isActiveMatchCandidate(
+  bestMatch: MatchCandidate | null,
+  secondBestMatch: MatchCandidate | null,
+  similarityThreshold: number,
+  matchMarginThreshold: number
+): boolean {
+  const isWithinThreshold = !!bestMatch && bestMatch.distance <= similarityThreshold;
+  if (!isWithinThreshold) {
+    return false;
+  }
+
+  const bestMargin =
+    bestMatch && secondBestMatch ? secondBestMatch.distance - bestMatch.distance : null;
+  const marginBoostNearThreshold =
+    bestMatch && bestMatch.distance >= Math.max(similarityThreshold - 1, 0) ? 1 : 0;
+  const effectiveRequiredMargin = matchMarginThreshold + marginBoostNearThreshold;
+  const hasSufficientMargin = bestMargin === null || bestMargin >= effectiveRequiredMargin;
+  const isExactCrossConcertTie =
+    !!bestMatch &&
+    !!secondBestMatch &&
+    bestMatch.concert.id !== secondBestMatch.concert.id &&
+    bestMatch.distance === secondBestMatch.distance;
+
+  return hasSufficientMargin && !isExactCrossConcertTie;
+}
+
+function compareInlineVariantMatches(
+  current: InlineVariantMatch,
+  candidate: InlineVariantMatch
+): InlineVariantMatch {
+  if (current.cropVariant === 'full' && current.isActiveMatch) {
+    return current;
+  }
+
+  if (candidate.cropVariant === 'full' && candidate.isActiveMatch) {
+    return candidate;
+  }
+
+  if (current.isActiveMatch !== candidate.isActiveMatch) {
+    return current.isActiveMatch ? current : candidate;
+  }
+
+  const currentDistance = current.bestMatch?.distance ?? Number.POSITIVE_INFINITY;
+  const candidateDistance = candidate.bestMatch?.distance ?? Number.POSITIVE_INFINITY;
+  if (currentDistance !== candidateDistance) {
+    return currentDistance < candidateDistance ? current : candidate;
+  }
+
+  const currentMargin =
+    current.bestMatch && current.secondBestMatch
+      ? current.secondBestMatch.distance - current.bestMatch.distance
+      : Number.POSITIVE_INFINITY;
+  const candidateMargin =
+    candidate.bestMatch && candidate.secondBestMatch
+      ? candidate.secondBestMatch.distance - candidate.bestMatch.distance
+      : Number.POSITIVE_INFINITY;
+
+  return currentMargin >= candidateMargin ? current : candidate;
+}
+
 function getHashBucketKey(hash: string): string {
   return hash.slice(0, HASH_BUCKET_PREFIX_LENGTH).toLowerCase();
 }
@@ -323,6 +396,7 @@ export interface BuildDebugInfoArgs {
   similarityThreshold: number;
   recognitionDelay: number;
   frameQuality: FrameQualityInfo | null;
+  recognitionCropVariant?: RecognitionCropVariantId | null;
   telemetry: RecognitionTelemetry;
 }
 
@@ -363,6 +437,7 @@ export function buildDebugInfo(args: BuildDebugInfoArgs): RecognitionDebugInfo {
     similarityThreshold: args.similarityThreshold,
     recognitionDelay: args.recognitionDelay,
     frameQuality: args.frameQuality,
+    recognitionCropVariant: args.recognitionCropVariant ?? null,
     telemetry: args.telemetry,
     hashAlgorithm: 'phash',
   };
@@ -391,6 +466,7 @@ export function usePhotoRecognition(
     enableRectangleDetection = false,
     rectangleConfidenceThreshold = 0.35,
     displayAspectRatio = DEFAULT_DISPLAY_ASPECT_RATIO,
+    demoCropFallbackEnabled = false,
   } = options;
 
   const [recognizedConcert, setRecognizedConcert] = useState<Concert | null>(null);
@@ -624,6 +700,7 @@ export function usePhotoRecognition(
       similarityThreshold,
       matchMarginThreshold,
       qualityGatingDistanceThreshold: QUALITY_GATING_DISTANCE_THRESHOLD,
+      demoCropFallbackEnabled,
       quality: {
         sharpnessThreshold,
         glareThreshold: glareThreshold ?? 250,
@@ -640,6 +717,7 @@ export function usePhotoRecognition(
       glarePercentageThreshold,
       minBrightness,
       maxBrightness,
+      demoCropFallbackEnabled,
     ]
   );
 
@@ -1188,37 +1266,113 @@ export function usePhotoRecognition(
         }
 
         const frameCaptureStartAt = performance.now();
-        // Downscale directly to 64×64 during capture so getImageData() only
-        // returns 4 096 pixels instead of the full framed-region dimensions
-        // (often 200 000+ pixels). The browser's canvas drawImage() performs
-        // hardware-accelerated bilinear downscaling. computePHash() will then
-        // resize 64×64 → 32×32, which is nearly free.
         const CAPTURE_SIZE = 64;
-        canvas.width = CAPTURE_SIZE;
-        canvas.height = CAPTURE_SIZE;
-        context.drawImage(
-          video,
-          framedRegion.x,
-          framedRegion.y,
+        const variants = getRecognitionCropVariants(
           framedRegion.width,
           framedRegion.height,
-          0,
-          0,
-          CAPTURE_SIZE,
-          CAPTURE_SIZE
+          demoCropFallbackEnabled
         );
+        let selectedVariant: InlineVariantMatch | null = null;
+        let fullFrameImageData: ImageData | null = null;
 
-        const imageData = context.getImageData(0, 0, CAPTURE_SIZE, CAPTURE_SIZE);
+        const algorithmStartAt = performance.now();
+        comparedCandidates = 0;
 
-        frameCaptureMs = performance.now() - frameCaptureStartAt;
+        telemetryRef.current.index_mode_used = (telemetryRef.current.index_mode_used ?? 0) + 1;
 
-        // Pre-hash blur gate: skip computePHash entirely when the 64×64 image is
-        // clearly blurry. Uses PRE_HASH_BLUR_GATE_FRACTION × sharpnessThreshold as
-        // a conservative cutoff — the lower resolution produces lower Laplacian
-        // variance, so only frames that would certainly fail the 128×128 gate fire
-        // this early exit, saving ~1–2ms of DCT computation per blurry frame.
-        const preHashVariance = computeLaplacianVariance(imageData);
-        if (preHashVariance < sharpnessThreshold * PRE_HASH_BLUR_GATE_FRACTION) {
+        for (const variant of variants) {
+          const variantRegion = {
+            x: framedRegion.x + variant.x,
+            y: framedRegion.y + variant.y,
+            width: variant.width,
+            height: variant.height,
+          };
+
+          // Downscale directly to 64×64 during capture so getImageData() only
+          // returns 4 096 pixels instead of the full framed-region dimensions.
+          canvas.width = CAPTURE_SIZE;
+          canvas.height = CAPTURE_SIZE;
+          context.drawImage(
+            video,
+            variantRegion.x,
+            variantRegion.y,
+            variantRegion.width,
+            variantRegion.height,
+            0,
+            0,
+            CAPTURE_SIZE,
+            CAPTURE_SIZE
+          );
+
+          const imageData = context.getImageData(0, 0, CAPTURE_SIZE, CAPTURE_SIZE);
+          if (variant.id === 'full') {
+            fullFrameImageData = imageData;
+            frameCaptureMs = performance.now() - frameCaptureStartAt;
+          }
+
+          const currentHashForVariant = computePHash(imageData);
+          const bucketCandidates =
+            concertHashBuckets.get(getHashBucketKey(currentHashForVariant)) ?? [];
+          comparedCandidates += bucketCandidates.length;
+          const { bestMatch: variantBestMatch, secondBestMatch: variantSecondBestMatch } =
+            findBestMatches(currentHashForVariant, bucketCandidates);
+          const variantMatch: InlineVariantMatch = {
+            cropVariant: variant.id,
+            hash: currentHashForVariant,
+            bestMatch: variantBestMatch,
+            secondBestMatch: variantSecondBestMatch,
+            isActiveMatch: isActiveMatchCandidate(
+              variantBestMatch,
+              variantSecondBestMatch,
+              similarityThreshold,
+              matchMarginThreshold
+            ),
+            region: variantRegion,
+            imageData,
+          };
+
+          selectedVariant = selectedVariant
+            ? compareInlineVariantMatches(selectedVariant, variantMatch)
+            : variantMatch;
+
+          if (variantMatch.isActiveMatch) {
+            break;
+          }
+        }
+
+        if (!selectedVariant) {
+          selectedVariant = {
+            cropVariant: 'full',
+            hash: '',
+            bestMatch: null,
+            secondBestMatch: null,
+            isActiveMatch: false,
+            region: framedRegion,
+            imageData: fullFrameImageData ?? new ImageData(CAPTURE_SIZE, CAPTURE_SIZE),
+          };
+        }
+
+        algorithmMs = performance.now() - algorithmStartAt;
+
+        const currentHash = selectedVariant.hash;
+        const bestMatch = selectedVariant.bestMatch;
+        const secondBestMatch = selectedVariant.secondBestMatch;
+        const selectedRegion = selectedVariant.region;
+        const recognitionCropVariant = selectedVariant.cropVariant;
+        const selectedImageData = selectedVariant.imageData;
+
+        // Pre-hash blur gate: reject clearly blurry full-frame captures before
+        // they can affect recognition state. Demo crop fallback bypasses this
+        // early exit
+        // because the full frame may be blurred or overlaid while a trimmed
+        // blog-photo crop is still recognizable.
+        const preHashVariance = fullFrameImageData
+          ? computeLaplacianVariance(fullFrameImageData)
+          : sharpnessThreshold;
+        if (
+          !demoCropFallbackEnabled &&
+          preHashVariance < sharpnessThreshold * PRE_HASH_BLUR_GATE_FRACTION
+        ) {
           consecutiveBlurFramesRef.current += 1;
           if (consecutiveBlurFramesRef.current >= BLUR_REJECTION_CONSECUTIVE_FRAMES) {
             telemetryRef.current.blurRejections += 1;
@@ -1240,24 +1394,6 @@ export function usePhotoRecognition(
           }
           return;
         }
-
-        // Hash matching — bucketed full-image scan only
-        const algorithmStartAt = performance.now();
-        const currentHash = computePHash(imageData);
-        comparedCandidates = 0;
-
-        const runMatchScan = (candidates: ReadonlyArray<HashEntry>) => {
-          comparedCandidates += candidates.length;
-          return findBestMatches(currentHash, candidates);
-        };
-
-        telemetryRef.current.index_mode_used = (telemetryRef.current.index_mode_used ?? 0) + 1;
-
-        const bucketCandidates = concertHashBuckets.get(getHashBucketKey(currentHash)) ?? [];
-
-        const { bestMatch, secondBestMatch } = runMatchScan(bucketCandidates);
-
-        algorithmMs = performance.now() - algorithmStartAt;
 
         const candidateTelemetry = telemetryRef.current.candidate_count_per_frame;
         if (candidateTelemetry) {
@@ -1304,16 +1440,16 @@ export function usePhotoRecognition(
         // When quality checks are needed, re-capture at QUALITY_CAPTURE_SIZE so
         // that resolution-sensitive metrics (especially Laplacian variance for
         // sharpness) are not distorted by the downscaled 64×64 hash image.
-        let qualityImageData = imageData;
+        let qualityImageData = selectedImageData;
         if (shouldRunQualityCheck) {
           canvas.width = QUALITY_CAPTURE_SIZE;
           canvas.height = QUALITY_CAPTURE_SIZE;
           context.drawImage(
             video,
-            framedRegion.x,
-            framedRegion.y,
-            framedRegion.width,
-            framedRegion.height,
+            selectedRegion.x,
+            selectedRegion.y,
+            selectedRegion.width,
+            selectedRegion.height,
             0,
             0,
             QUALITY_CAPTURE_SIZE,
@@ -1340,11 +1476,12 @@ export function usePhotoRecognition(
                 frameCount: frameCountRef.current,
                 checkInterval,
                 aspectRatio: chosenAspectRatio,
-                framedRegion,
+                framedRegion: selectedRegion,
                 stability: null,
                 similarityThreshold,
                 recognitionDelay,
                 frameQuality: quality,
+                recognitionCropVariant,
                 telemetry: { ...telemetryRef.current },
               })
             );
@@ -1402,11 +1539,12 @@ export function usePhotoRecognition(
               frameCount: frameCountRef.current,
               checkInterval,
               aspectRatio: chosenAspectRatio,
-              framedRegion,
+              framedRegion: selectedRegion,
               stability,
               similarityThreshold,
               recognitionDelay,
               frameQuality: quality,
+              recognitionCropVariant,
               telemetry: { ...telemetryRef.current },
             })
           );
@@ -1777,6 +1915,7 @@ export function usePhotoRecognition(
             similarityThreshold,
             recognitionDelay,
             frameQuality: workerFrameQuality,
+            recognitionCropVariant: result.cropVariant,
             telemetry: { ...telemetryRef.current },
           })
         );
@@ -1975,6 +2114,7 @@ export function usePhotoRecognition(
     enableRectangleDetection,
     rectangleConfidenceThreshold,
     displayAspectRatio,
+    demoCropFallbackEnabled,
     markStartupMilestone,
     restartKey,
     // isWorkerSupported, isWorkerReady, workerProcessFrame are intentionally

--- a/src/modules/photo-recognition/useRecognitionWorker.test.ts
+++ b/src/modules/photo-recognition/useRecognitionWorker.test.ts
@@ -82,6 +82,7 @@ function makeResult(overrides: Partial<WorkerFrameResult> = {}): WorkerFrameResu
     type: 'result',
     frameId: 1,
     hash: 'aaaaaaaaaaaaaaaa',
+    cropVariant: 'full',
     bestMatch: null,
     secondBestMatch: null,
     quality: null,

--- a/src/modules/photo-recognition/worker-protocol.ts
+++ b/src/modules/photo-recognition/worker-protocol.ts
@@ -1,3 +1,5 @@
+import type { RecognitionCropVariantId } from './recognitionCropVariants';
+
 /**
  * Recognition Worker Protocol
  *
@@ -31,6 +33,8 @@ export interface WorkerRecognitionConfig {
   similarityThreshold: number;
   matchMarginThreshold: number;
   qualityGatingDistanceThreshold: number;
+  /** Demo-only fallback that evaluates overlay-tolerant crop variants. */
+  demoCropFallbackEnabled?: boolean;
   quality: WorkerQualityConfig;
 }
 
@@ -99,6 +103,8 @@ export interface WorkerFrameResult {
   type: 'result';
   frameId: number;
   hash: string;
+  /** Crop variant that produced the selected hash/match. */
+  cropVariant: RecognitionCropVariantId;
   bestMatch: WorkerMatchResult | null;
   secondBestMatch: WorkerMatchResult | null;
   /** null when quality checks were skipped (distance ≤ gating threshold). */


### PR DESCRIPTION
## Summary
- Add demo-only overlay-tolerant recognition crop variants for remote blog-screen scans
- Keep gallery/exhibit recognition behavior on the existing full crop path
- Surface selected crop variant metadata in the debug overlay

## Why
Remote demo users may point their phone at blog images on a computer screen, where browser chrome, page text, or the blog download overlay can land inside the recognition frame. The demo path now tries conservative vertical crop variants before giving up, without loosening thresholds or changing the main exhibit experience.

## Validation
- npm run pre-commit
  - lint:fix
  - format
  - type-check
  - module README check
  - test:run: 57 files passed, 1047 passed, 3 skipped
  - build
  - bundle-size check
