### PR TITLE
docs: improve CLAUDE.md with standard header and single-test commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# CLAUDE.md — Photo Signal
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 > **Sync note**: This is the canonical AI agent instruction source. `.github/copilot-instructions.md`
 > is derived from this document and kept consistent for overlapping sections — it is not identical
@@ -83,8 +85,16 @@ npm run pre-commit
 
 # Testing
 npm run test             # Vitest watch mode
+npm run test:run         # Run all tests once (same as CI)
 npm run test:coverage    # Coverage report (70% minimum threshold)
 npm run test:visual      # Playwright visual regression (builds first)
+
+# Run a single test file or directory
+npx vitest run src/modules/audio-playback
+npx vitest run src/modules/audio-playback/audio-playback.test.ts
+
+# Run tests matching a name pattern
+npx vitest run --reporter=verbose -t "matches photo"
 
 # Photo recognition data
 npm run hashes:refresh   # Regenerate pHash hashes for all photos (safe batching)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ npm run test:visual      # Playwright visual regression (builds first)
 
 # Run a single test file or directory
 npx vitest run src/modules/audio-playback
-npx vitest run src/modules/audio-playback/audio-playback.test.ts
+npx vitest run src/modules/audio-playback/useAudioPlayback.test.ts
 
 # Run tests matching a name pattern
 npx vitest run --reporter=verbose -t "matches photo"


### PR DESCRIPTION
## Summary

- Add the required Claude Code guidance prefix (`This file provides guidance to Claude Code...`) to the CLAUDE.md header, replacing the informal `# CLAUDE.md — Photo Signal` title
- Document how to run a single Vitest test file, directory, or name pattern — previously the Quick Reference only covered full-suite runs

## What changed and why

The `/init` skill convention expects CLAUDE.md to open with a standard header line so Claude Code instances recognize the file's purpose immediately. The old title was redundant with the project identity section below it.

The single-test commands (`npx vitest run <path>` and `-t "<pattern>"`) are the most common commands used during active development but were absent from the docs, meaning agents had to guess the Vitest CLI syntax each time.

## Reviewer notes

No code changes — documentation only. Pre-commit passed (56 test files, bundle within limits).